### PR TITLE
Prompt for save on keyconfig close

### DIFF
--- a/IO/UITypes/UIKeyConfig.h
+++ b/IO/UITypes/UIKeyConfig.h
@@ -44,6 +44,7 @@ namespace ms
 
 		void remove_key(KeyAction::Id action);
 		void add_key(Point<int16_t> cursorposition, KeyAction::Id action);
+		void save_keys();
 
 		void close();
 


### PR DESCRIPTION
Resolves: https://github.com/ryantpayton/HeavenClient/issues/4:

> It's possible for a player to rearrange their key configurations and exit the window without first saving their new config.

- Move save logic into its own function
- Add logic for "ok" UI element on cancel
- Cleanup switch statement