### PR TITLE
Fix skill book button mapping

### DIFF
--- a/IO/UITypes/UISkillbook.cpp
+++ b/IO/UITypes/UISkillbook.cpp
@@ -771,7 +771,7 @@ namespace ms
 	{
 		int16_t x = cursorpos.x();
 
-		if (x < SKILL_OFFSET.x() || x > 148)
+		if (x < SKILL_OFFSET.x() || x > SKILL_OFFSET.x() + 2 * ROW_WIDTH)
 			return nullptr;
 
 		int16_t y = cursorpos.y();
@@ -784,12 +784,19 @@ namespace ms
 		if (row < 0 || row >= ROWS)
 			return nullptr;
 
-		uint16_t absrow = offset + row;
+		uint16_t offset_row = offset + row;
 
-		if (icons.size() <= absrow)
+		if (offset_row >= ROWS)
 			return nullptr;
 
-		auto iter = icons.begin() + absrow;
+		uint16_t col = (x - SKILL_OFFSET.x()) / ROW_WIDTH;
+
+		uint16_t icon_idx = 2 * offset_row + col;
+
+		if (icon_idx >= icons.size())
+			return nullptr;
+
+		auto iter = icons.begin() + icon_idx;
 
 		return iter._Ptr;
 	}


### PR DESCRIPTION
Fixes https://github.com/ryantpayton/HeavenClient/issues/10:

> AreaButtons in the Skill Book Window (Default basic key: K) are mapped incorrectly: instead of being row-first, the buttons are arranged column-first. This causes skills being used to be different than what the button shows.

I don't think `ROWS` is really an accurate concept anymore since the skills are split into two columns. I avoided refactoring this logic for now since I was told new features may be being worked on in UISkillbook already. Best to save the refactor once we know all changes are in.