### PR TITLE
NPC List on Minimap

### DIFF
--- a/Gameplay/Maplemap/Npc.cpp
+++ b/Gameplay/Maplemap/Npc.cpp
@@ -150,4 +150,14 @@ namespace ms
 			absp.y()
 			).contains(cursorpos);
 	}
+
+	std::string Npc::get_name()
+	{
+		return name;
+	}
+
+	std::string Npc::get_func()
+	{
+		return func;
+	}
 }

--- a/Gameplay/Maplemap/Npc.h
+++ b/Gameplay/Maplemap/Npc.h
@@ -47,6 +47,11 @@ namespace ms
 		// Check if the NPC is in range of the cursor.
 		bool inrange(Point<int16_t> cursorpos, Point<int16_t> viewpos) const;
 
+		// Returns the NPC name.
+		std::string get_name();
+		// Returns the NPC's function description or title.
+		std::string get_func();
+
 	private:
 		std::map<std::string, Animation> animations;
 		std::map<std::string, std::vector<std::string>> lines;

--- a/Gameplay/Stage.cpp
+++ b/Gameplay/Stage.cpp
@@ -76,6 +76,7 @@ namespace ms
 
 	void Stage::load_map(int32_t mapid)
 	{
+		Stage::mapid = mapid;
 		std::string strid = string_format::extend_id(mapid, 9);
 		std::string prefix = std::to_string(mapid / 100000000);
 		nl::node src = nl::nx::map["Map"]["Map" + prefix][strid + ".img"];
@@ -315,6 +316,11 @@ namespace ms
 			return player;
 		else
 			return chars.get_char(cid);
+	}
+
+	int Stage::get_mapid()
+	{
+		return mapid;
 	}
 
 	void Stage::add_effect(std::string path)

--- a/Gameplay/Stage.h
+++ b/Gameplay/Stage.h
@@ -85,6 +85,8 @@ namespace ms
 		Player& get_player();
 		// Return a reference to the attack and buff component.
 		Combat& get_combat();
+		// Returns the current map ID.
+		int32_t get_mapid();
 
 		// Return a pointer to a character, possibly the player.
 		Optional<Char> get_character(int32_t cid);
@@ -113,6 +115,7 @@ namespace ms
 
 		Optional<Playable> playable;
 		State state;
+		int32_t mapid;
 
 		MapInfo mapinfo;
 		MapTilesObjs tilesobjs;

--- a/Graphics/Animation.h
+++ b/Graphics/Animation.h
@@ -65,7 +65,7 @@ namespace ms
 		bool update(uint16_t timestep);
 		void reset();
 
-		void draw(const DrawArgument& arguments, float inter) const;
+		void draw(const DrawArgument& arguments, float alpha) const;
 
 		uint16_t get_delay(int16_t frame) const;
 		uint16_t getdelayuntil(int16_t frame) const;

--- a/IO/UITypes/UIMiniMap.cpp
+++ b/IO/UITypes/UIMiniMap.cpp
@@ -22,17 +22,21 @@
 
 #include "../Components/MapleButton.h"
 
+#include "../Gameplay/Maplemap/Npc.h"
+
 #include <nlnx/nx.hpp>
 
 namespace ms
 {
-	UIMiniMap::UIMiniMap(const CharStats& st) : UIDragElement<PosMINIMAP>(Point<int16_t>(128, 20)), stats(st), big_map(true)
+	UIMiniMap::UIMiniMap(const CharStats& st) : UIDragElement<PosMINIMAP>(Point<int16_t>(128, 20)), stats(st), 
+		big_map(true), has_map(false), listNpc_enabled(false), listNpc_dimensions(Point<int16_t>(150, 170)), listNpc_offset(0), selected(-1)
 	{
 		type = Setting<MiniMapType>::get().load();
 		simpleMode = Setting<MiniMapSimpleMode>::get().load();
 
 		std::string node = simpleMode ? "MiniMapSimpleMode" : "MiniMap";
 		MiniMap = nl::nx::ui["UIWindow2.img"][node];
+		listNpc = nl::nx::ui["UIWindow2.img"]["MiniMap"]["ListNpc"];
 
 		buttons[Buttons::BT_MIN] = std::make_unique<MapleButton>(MiniMap["BtMin"], Point<int16_t>(195, -6));
 		buttons[Buttons::BT_MAX] = std::make_unique<MapleButton>(MiniMap["BtMax"], Point<int16_t>(209, -6));
@@ -48,8 +52,9 @@ namespace ms
 		marker = Setting<MiniMapDefaultHelpers>::get().load() ? nl::nx::ui["UIWindow2.img"]["MiniMapSimpleMode"]["DefaultHelper"] : nl::nx::map["MapHelper.img"]["minimap"];
 
 		player_marker = Animation(marker["user"]);
+		selected_marker = Animation(MiniMap["iconNpc"]);
 
-		position.shift_y(-Constants::VIEWYOFFSET);
+		//position.shift_y(-Constants::VIEWYOFFSET);
 	}
 
 	void UIMiniMap::draw(float alpha) const
@@ -72,6 +77,11 @@ namespace ms
 					sprite.draw(position, alpha);
 
 				draw_movable_markers(position, alpha);
+				
+				if (listNpc_enabled)
+				{
+					draw_npclist(normal_dimensions, alpha);
+				}
 			}
 		}
 		else
@@ -88,6 +98,10 @@ namespace ms
 					sprite.draw(position + Point<int16_t>(0, max_adj), alpha);
 
 				draw_movable_markers(position + Point<int16_t>(0, max_adj), alpha);
+
+				if (listNpc_enabled) {
+					draw_npclist(max_dimensions, alpha);
+				}
 			}
 		}
 
@@ -96,7 +110,7 @@ namespace ms
 
 	void UIMiniMap::update()
 	{
-		int32_t mid = stats.get_mapid();
+		int32_t mid = Stage::get().get_mapid();
 
 		if (mid != mapid)
 		{
@@ -115,6 +129,7 @@ namespace ms
 			update_canvas();
 			update_static_markers();
 			toggle_buttons();
+			update_npclist();
 		}
 
 		if (type == Type::MIN)
@@ -137,7 +152,53 @@ namespace ms
 			for (auto sprite : static_marker_sprites)
 				sprite.update();
 
+		if (listNpc_enabled)
+			for each (Sprite s in listNpc_sprites)
+				s.update();
+
+		if (selected >= 0)
+		{
+			selected_marker.update();
+		}
+
 		UIElement::update();
+	}
+
+	Cursor::State UIMiniMap::send_cursor(bool clicked, Point<int16_t> cursorpos)
+	{
+		Cursor::State dstate = UIDragElement::send_cursor(clicked, cursorpos);
+
+		if (dragged)
+			return dstate;
+
+		Point<int16_t> cursor_relative = cursorpos - position;
+
+		if (listNpc_slider.isenabled())
+		{
+			if (Cursor::State new_state = listNpc_slider.send_cursor(cursor_relative, clicked))
+			{
+				return new_state;
+			}
+		}
+
+		if (listNpc_enabled && clicked)
+		{
+			Point<int16_t> clicked_point = cursor_relative - Point<int16_t>(10 + (type == Type::MAX ? max_dimensions : normal_dimensions).x(), 23);
+			Rectangle<int16_t> list_bounds(0, listNpc_item_width, 0, listNpc_item_height * 8);
+			if (list_bounds.contains(clicked_point))
+			{
+				int16_t clicked_item = listNpc_offset + clicked_point.y() / listNpc_item_height;
+				select_npclist(clicked_item < listNpc_names.size() ? clicked_item :  -1);
+			}
+		}
+
+		return Cursor::State::IDLE;
+	}
+
+	void UIMiniMap::send_scroll (double yoffset)
+	{
+		if (listNpc_enabled && listNpc_slider.isenabled())
+			listNpc_slider.send_scroll(yoffset);
 	}
 
 	void UIMiniMap::send_key(int32_t keycode, bool pressed, bool escape)
@@ -173,6 +234,7 @@ namespace ms
 			break;
 		case BT_NPC:
 			// TODO: make NPC submenu
+			set_npclist_active(!listNpc_enabled);
 			break;
 		}
 
@@ -217,9 +279,13 @@ namespace ms
 
 			buttons[Buttons::BT_MAP]->set_position(Point<int16_t>(bt_min_x, btn_min_y));
 
-			dimension = Point<int16_t>(bt_min_x + bt_map_width + 7, 20);
+			min_dimensions = Point<int16_t>(bt_min_x + bt_map_width + 7, 20);
+
+			update_dimensions();
 
 			dragarea = dimension;
+
+			set_npclist_active(false);
 		}
 		else
 		{
@@ -264,14 +330,14 @@ namespace ms
 
 			if (type == Type::MAX)
 			{
-				dimension = normal_dimensions;
 				buttons[Buttons::BT_MAX]->set_state(Button::State::DISABLED);
 			}
 			else
 			{
-				dimension = max_dimensions;
 				buttons[Buttons::BT_MAX]->set_state(Button::State::NORMAL);
 			}
+
+			set_npclist_active(listNpc_enabled);
 
 			dragarea = Point<int16_t>(dimension.x(), 20);
 		}
@@ -321,8 +387,9 @@ namespace ms
 			Max = MiniMap["MaxMap"];
 		}
 
-		Animation map_sprite = Animation(Map["miniMap"]["canvas"]);
+		map_sprite = Texture(Map["miniMap"]["canvas"]);
 		Point<int16_t> map_dimensions = map_sprite.get_dimensions();
+		
 
 		// 48 (Offset for text) + longer text's width + 10 (space for right side border)
 		int16_t mark_text_width = 48 + std::max(region_text.width(), town_text.width()) + 10;
@@ -411,6 +478,7 @@ namespace ms
 		max_sprites.emplace_back(nl::nx::map["MapHelper.img"]["mark"][Map["info"]["mapMark"]], DrawArgument(Point<int16_t>(7, 16)));
 
 		max_dimensions = normal_dimensions + Point<int16_t>(0, max_adj);
+
 	}
 
 	nl::node UIMiniMap::get_map_node_name()
@@ -483,6 +551,162 @@ namespace ms
 				Point<int16_t> marker_pos = (Point<int16_t>(portal["x"], portal["y"]) + center_offset) / scale - marker_offset + Point<int16_t>(map_draw_origin_x, map_draw_origin_y);
 				static_marker_sprites.emplace_back(marker_sprite, marker_pos);
 			}
+		}
+	}
+
+	void UIMiniMap::set_npclist_active(bool active)
+	{
+		if (type == Type::MIN) {
+			listNpc_enabled = false;
+			select_npclist(-1);
+		}
+		else {
+			listNpc_enabled = active;
+		}
+
+		update_dimensions();
+	}
+
+	void UIMiniMap::update_dimensions()
+	{
+		if (type == Type::MIN)
+		{
+			dimension = min_dimensions;
+		}
+		else
+		{
+			Point<int16_t> base_dims = type == Type::MAX ? max_dimensions : normal_dimensions;
+			dimension = base_dims;
+			if (listNpc_enabled) {
+				dimension += listNpc_dimensions;
+				dimension.set_y(std::max(base_dims.y(), listNpc_dimensions.y()));
+			}
+		}
+	}
+
+	void UIMiniMap::update_npclist()
+	{
+		listNpc_sprites.clear();
+		listNpc_names.clear();
+		listNpc_list.clear();
+		selected = -1;
+		listNpc_offset = 0;
+
+		if (simpleMode)
+			return;
+
+		MapObjects *npcs = Stage::get().get_npcs().get_npcs();
+		for (auto npc = npcs->begin(); npc != npcs->end(); ++npc)
+		{
+			listNpc_list.emplace_back(npc->second.get());
+
+			Npc* n = static_cast<Npc*>(npc->second.get());
+			std::string name = n->get_name();
+			if (n->get_func() != "")
+				name += " (" + n->get_func() + ")";
+
+			Text name_text = Text(Text::Font::A11M, Text::Alignment::LEFT, Color::Name::WHITE, name);
+
+			// Stopgap solution to truncating names until Text supports truncation...
+			while (name_text.width() > listNpc_text_width)
+			{
+				name.pop_back();
+				name_text.change_text(name + "..");
+			}
+			listNpc_names.emplace_back(name_text);
+		}
+
+		const Point<int16_t> listNpc_pos = Point<int16_t>(type == Type::MAX ? max_dimensions.x() : normal_dimensions.x(), 0);
+		int16_t c_stretch = 20;
+		int16_t m_stretch = 102;
+
+		if (listNpc_names.size() > 8)
+		{
+			listNpc_slider = Slider(Slider::DEFAULT, Range<int16_t>(23, 11 + listNpc_item_height * 8), listNpc_pos.x() + listNpc_item_width + 13, 8, listNpc_names.size(), 
+			[&](bool upwards) 
+			{
+				int16_t shift = upwards ? -1 : 1;
+				bool above = listNpc_offset + shift >= 0;
+				bool below = listNpc_offset + 8 + shift <= listNpc_names.size();
+
+				if (above && below)
+					listNpc_offset += shift;
+			});
+			c_stretch += 12;
+		}
+		else
+		{
+			listNpc_slider.setenabled(false);
+			m_stretch = listNpc_item_height * listNpc_names.size() - 34;
+		}
+
+		listNpc_sprites.emplace_back(listNpc["c"], DrawArgument(listNpc_pos + Point<int16_t>(center_start_x, m_start), Point<int16_t>(c_stretch, m_stretch)));
+		listNpc_sprites.emplace_back(listNpc["w"], DrawArgument(listNpc_pos + Point<int16_t>(0, m_start), Point<int16_t>(0, m_stretch)));
+		listNpc_sprites.emplace_back(listNpc["e"], DrawArgument(listNpc_pos + Point<int16_t>(center_start_x+c_stretch, m_start), Point<int16_t>(0, m_stretch)));
+		listNpc_sprites.emplace_back(listNpc["n"], DrawArgument(listNpc_pos + Point<int16_t>(center_start_x, 0), Point<int16_t>(c_stretch, 0)));
+		listNpc_sprites.emplace_back(listNpc["s"], DrawArgument(listNpc_pos + Point<int16_t>(center_start_x, m_start+m_stretch), Point<int16_t>(c_stretch, 0)));
+		listNpc_sprites.emplace_back(listNpc["nw"], DrawArgument(listNpc_pos + Point<int16_t>(0, 0)));
+		listNpc_sprites.emplace_back(listNpc["ne"], DrawArgument(listNpc_pos + Point<int16_t>(center_start_x+c_stretch, 0)));
+		listNpc_sprites.emplace_back(listNpc["sw"], DrawArgument(listNpc_pos + Point<int16_t>(0, m_start + m_stretch)));
+		listNpc_sprites.emplace_back(listNpc["se"], DrawArgument(listNpc_pos + Point<int16_t>(center_start_x+c_stretch, m_start+m_stretch))); 
+		
+		listNpc_dimensions = Point<int16_t>(center_start_x * 2 + c_stretch, m_start + m_stretch + 30);
+
+		update_dimensions();
+	}
+
+	void UIMiniMap::draw_npclist(Point<int16_t> minimap_dims, float alpha) const
+	{
+		Animation npc_marker = Animation(marker["npc"]);
+
+		for each (Sprite s in listNpc_sprites)
+			s.draw(position, alpha);
+
+		Point<int16_t> listNpc_pos = position + Point<int16_t>(minimap_dims.x() + 10, 23);
+
+		for (int8_t i = 0; i + listNpc_offset < listNpc_list.size() && i < 8; i++)
+		{
+			if (selected - listNpc_offset == i)
+			{
+				ColorBox highlight = ColorBox(listNpc_item_width, listNpc_item_height, Color::Name::YELLOW, 1.0f);
+				highlight.draw(listNpc_pos);
+			}
+
+			npc_marker.draw(DrawArgument(listNpc_pos + Point<int16_t>(2, 7), false, npc_marker.get_dimensions()/2), alpha);
+			listNpc_names[listNpc_offset + i].draw(DrawArgument(listNpc_pos + Point<int16_t>(11, -3)));
+
+			listNpc_pos.shift_y(listNpc_item_height);
+		}
+
+		if (listNpc_slider.isenabled())
+		{
+			listNpc_slider.draw(position);
+		}
+
+		if (selected >= 0)
+		{
+			Point<int16_t> npc_pos = (listNpc_list[selected]->get_position() + center_offset) / scale
+				+ Point<int16_t>(map_draw_origin_x, map_draw_origin_y - npc_marker.get_dimensions().y() + (type == Type::MAX ? max_adj : 0));
+			selected_marker.draw(position + npc_pos, 0.5f);
+		}
+	}
+
+	void UIMiniMap::select_npclist(int16_t choice)
+	{
+		if (selected >= 0 && selected < listNpc_names.size())
+		{
+			listNpc_names[selected].change_color(Color::Name::WHITE);
+		}
+
+		if (choice > listNpc_names.size() || choice < 0)
+		{
+			selected = -1;
+		}
+		else
+		{
+			selected = choice != selected ? choice : -1;
+			if (selected >= 0)
+				listNpc_names[selected].change_color(Color::Name::BLACK);
 		}
 	}
 }

--- a/IO/UITypes/UIMiniMap.cpp
+++ b/IO/UITypes/UIMiniMap.cpp
@@ -54,7 +54,7 @@ namespace ms
 		player_marker = Animation(marker["user"]);
 		selected_marker = Animation(MiniMap["iconNpc"]);
 
-		//position.shift_y(-Constants::VIEWYOFFSET);
+		position.shift_y(-Constants::VIEWYOFFSET);
 	}
 
 	void UIMiniMap::draw(float alpha) const
@@ -233,7 +233,6 @@ namespace ms
 			UI::get().emplace<UIWorldMap>();
 			break;
 		case BT_NPC:
-			// TODO: make NPC submenu
 			set_npclist_active(!listNpc_enabled);
 			break;
 		}

--- a/IO/UITypes/UIMiniMap.h
+++ b/IO/UITypes/UIMiniMap.h
@@ -23,6 +23,10 @@
 #include "../Character/Charstats.h"
 #include "../Gameplay/Stage.h"
 
+#include "../Components/MapleButton.h"
+#include "../Components/AreaButton.h"
+#include "../Components/Slider.h"
+
 namespace ms
 {
 	class UIMiniMap : public UIDragElement<PosMINIMAP>
@@ -37,6 +41,8 @@ namespace ms
 		void draw(float alpha) const override;
 		void update() override;
 
+		Cursor::State send_cursor(bool clicked, Point<int16_t> pos) override;
+		void UIMiniMap::send_scroll(double yoffset) override;
 		void send_key(int32_t keycode, bool pressed, bool escape) override;
 		Button::State button_pressed(uint16_t buttonid) override;
 
@@ -54,6 +60,16 @@ namespace ms
 		void update_canvas();
 		void draw_movable_markers(Point<int16_t> init_pos, float alpha) const;
 		void update_static_markers();
+
+		void set_npclist_active(bool active);
+
+		void update_dimensions();
+
+		void update_npclist();
+
+		void draw_npclist(Point<int16_t> minimap_dims, float alpha) const;
+
+		void select_npclist(int16_t choice);
 
 		nl::node get_map_node_name();
 
@@ -84,6 +100,7 @@ namespace ms
 		nl::node Map;
 		nl::node MiniMap;
 		nl::node marker;
+		Texture map_sprite;
 		Animation player_marker;
 		int16_t combined_text_width;
 		int16_t middle_right_x;
@@ -96,10 +113,29 @@ namespace ms
 		std::vector<Sprite> static_marker_sprites;
 		int16_t map_draw_origin_x, map_draw_origin_y;
 		Point<int16_t> center_offset;
+		Point<int16_t> min_dimensions;
 		Point<int16_t> normal_dimensions;
 		Point<int16_t> max_dimensions;
 		Text combined_text;
 		Text region_text;
 		Text town_text;
+
+		bool listNpc_enabled;
+		nl::node listNpc;
+		std::vector<Sprite> listNpc_sprites;
+		std::vector<MapObject*> listNpc_list;
+		std::vector<Text> listNpc_names;
+
+		Point<int16_t> listNpc_dimensions;
+
+		const int16_t m_start = 36;
+		const int16_t listNpc_item_height = 17;
+		const int16_t listNpc_item_width = 128;
+		const int16_t listNpc_text_width = 114; 
+
+		Slider listNpc_slider;
+		int16_t listNpc_offset;
+		int16_t selected;
+		Animation selected_marker;
 	};
 }


### PR DESCRIPTION
Adds an NPC list to the MiniMap window.  

### Features  
- Click on an NPC name to get an arrow pointing at their marker/location. Click again to deselect  
- Scroll bar when number of NPCs exceeds maximum showed  

### Changes to Files not UIMiniMap.h/.cpp  
- **Npc.h/.cpp**: Added getters for NPC names and functions to print onto the list  
- **Stage.h/.cpp**: Re-added Map ID as an instance variable to synchronize NPC list read with map change, also fixes a bug where MiniMap's canvas isn't updated when using GM command !goto  
- **Animation.h**: Changed parameter name to be consistent with **Animation.cpp**

### Notes
- By UIElement's design, you can use the scroll wheel to scroll the list while pointing at anywhere. This may be an issue in the future where multiple windows are scrolled at once, or one window 'snatches' the scroll away.
- There are slight visual differences between this implementation and that of the official client.
- I am shelving the scrolling map feature for now, as it is quite a ways beyond my knowledge. I'll be moving on to the ghost monsters issue.

![image](https://user-images.githubusercontent.com/14435972/69907777-e3c59900-13a9-11ea-9269-037ab68ef4b6.png)