### PR TITLE
Refactor UISkillbook to utilize existing Icon functionality

### DIFF
--- a/IO/Components/Icon.cpp
+++ b/IO/Components/Icon.cpp
@@ -19,6 +19,7 @@
 #include "Charset.h"
 
 #include "../Audio/Audio.h"
+#include "../Graphics/Texture.h"
 #include "../Template/EnumMap.h"
 
 #include <nlnx/nx.hpp>

--- a/IO/Components/Icon.cpp
+++ b/IO/Components/Icon.cpp
@@ -26,10 +26,9 @@
 
 namespace ms
 {
-	Icon::Icon(std::unique_ptr<Type> t, Texture tx, int16_t c) : type(std::move(t)), count(c)
+	Icon::Icon(std::unique_ptr<Type> t, Texture tx, int16_t c) : type(std::move(t)), texture(tx), count(c)
 	{
-		tx.shift({ 0, 32 });
-		textures[Icon::State::NORMAL] = tx;
+		texture.shift({ 0, 32 });
 		showcount = c > -1;
 		dragged = false;
 	}
@@ -92,9 +91,12 @@ namespace ms
 		dragged = false;
 	}
 
+	/**
+	 * Allows for Icon extensibility. Use this instead of referencing texture directly.
+	 */
 	Texture Icon::get_texture() const
 	{
-		return textures[Icon::State::NORMAL];
+		return texture;
 	}
 
 	void Icon::set_count(int16_t c)

--- a/IO/Components/Icon.cpp
+++ b/IO/Components/Icon.cpp
@@ -19,14 +19,16 @@
 #include "Charset.h"
 
 #include "../Audio/Audio.h"
+#include "../Template/EnumMap.h"
 
 #include <nlnx/nx.hpp>
 
 namespace ms
 {
-	Icon::Icon(std::unique_ptr<Type> t, Texture tx, int16_t c) : type(std::move(t)), texture(tx), count(c)
+	Icon::Icon(std::unique_ptr<Type> t, Texture tx, int16_t c) : type(std::move(t)), count(c)
 	{
-		texture.shift({ 0, 32 });
+		tx.shift({ 0, 32 });
+		textures[Icon::State::NORMAL] = tx;
 		showcount = c > -1;
 		dragged = false;
 	}
@@ -36,7 +38,7 @@ namespace ms
 	void Icon::draw(Point<int16_t> position) const
 	{
 		float opacity = dragged ? 0.5f : 1.0f;
-		texture.draw({ position, opacity });
+		get_texture().draw({ position, opacity });
 
 		if (showcount)
 		{
@@ -48,7 +50,7 @@ namespace ms
 	void Icon::dragdraw(Point<int16_t> cursorpos) const
 	{
 		if (dragged)
-			texture.draw({ cursorpos - cursoroffset, 0.5f });
+			get_texture().draw({ cursorpos - cursoroffset, 0.5f });
 	}
 
 	void Icon::drop_on_stage() const
@@ -87,6 +89,11 @@ namespace ms
 	void Icon::reset()
 	{
 		dragged = false;
+	}
+
+	Texture Icon::get_texture() const
+	{
+		return textures[Icon::State::NORMAL];
 	}
 
 	void Icon::set_count(int16_t c)

--- a/IO/Components/Icon.h
+++ b/IO/Components/Icon.h
@@ -54,7 +54,7 @@ namespace ms
 			NORMAL = 0,
 			DISABLED,
 			MOUSEOVER,
-			LENGTH
+			LENGTH  // requirement for EnumMap
 		};
 
 		Icon(std::unique_ptr<Type> type, Texture texture, int16_t count);

--- a/IO/Components/Icon.h
+++ b/IO/Components/Icon.h
@@ -49,14 +49,6 @@ namespace ms
 			void set_count(int16_t) override {}
 		};
 
-		enum State: uint8_t
-		{
-			NORMAL = 0,
-			DISABLED,
-			MOUSEOVER,
-			LENGTH  // requirement for EnumMap
-		};
-
 		Icon(std::unique_ptr<Type> type, Texture texture, int16_t count);
 		Icon();
 
@@ -78,10 +70,8 @@ namespace ms
 		bool showcount;
 		int16_t count;
 
+		Texture texture;
 		bool dragged;
 		Point<int16_t> cursoroffset;
-
-	protected:
-		EnumMap<Icon::State, Texture> textures;
 	};
 }

--- a/IO/Components/Icon.h
+++ b/IO/Components/Icon.h
@@ -19,6 +19,7 @@
 
 #include "../Character/Inventory/Inventory.h"
 #include "../Graphics/Texture.h"
+#include "../Template/EnumMap.h"
 
 #include <memory>
 
@@ -48,6 +49,14 @@ namespace ms
 			void set_count(int16_t) override {}
 		};
 
+		enum State: uint8_t
+		{
+			NORMAL = 0,
+			DISABLED,
+			MOUSEOVER,
+			LENGTH
+		};
+
 		Icon(std::unique_ptr<Type> type, Texture texture, int16_t count);
 		Icon();
 
@@ -59,13 +68,14 @@ namespace ms
 		void drop_on_bindings(Point<int16_t> cursorposition, bool remove) const;
 		void start_drag(Point<int16_t> offset);
 		void reset();
+		Texture get_texture() const;
 		void set_count(int16_t count);
 		int16_t get_count() const;
 		bool get_drag();
 
 	private:
 		std::unique_ptr<Type> type;
-		Texture texture;
+		EnumMap<Icon::State, Texture> textures;
 		bool showcount;
 		int16_t count;
 

--- a/IO/Components/Icon.h
+++ b/IO/Components/Icon.h
@@ -75,11 +75,13 @@ namespace ms
 
 	private:
 		std::unique_ptr<Type> type;
-		EnumMap<Icon::State, Texture> textures;
 		bool showcount;
 		int16_t count;
 
 		bool dragged;
 		Point<int16_t> cursoroffset;
+
+	protected:
+		EnumMap<Icon::State, Texture> textures;
 	};
 }

--- a/IO/Components/Icon.h
+++ b/IO/Components/Icon.h
@@ -68,7 +68,7 @@ namespace ms
 		void drop_on_bindings(Point<int16_t> cursorposition, bool remove) const;
 		void start_drag(Point<int16_t> offset);
 		void reset();
-		Texture get_texture() const;
+		virtual Texture get_texture() const;
 		void set_count(int16_t count);
 		int16_t get_count() const;
 		bool get_drag();

--- a/IO/Components/StatefulIcon.cpp
+++ b/IO/Components/StatefulIcon.cpp
@@ -22,7 +22,7 @@
 
 namespace ms
 {
-	StatefulIcon::StatefulIcon(std::unique_ptr<Type> type, Texture ntx, Texture dtx, Texture motx) : Icon(type, ntx, count(-1))
+	StatefulIcon::StatefulIcon(std::unique_ptr<Type> type, Texture ntx, Texture dtx, Texture motx) : Icon(std::move(type), ntx, -1)
 	{
 		dtx.shift({ 0, 32 });
 		motx.shift({ 0, 32 });

--- a/IO/Components/StatefulIcon.cpp
+++ b/IO/Components/StatefulIcon.cpp
@@ -16,8 +16,9 @@
 //	along with this program.  If not, see <https://www.gnu.org/licenses/>.		//
 //////////////////////////////////////////////////////////////////////////////////
 #include "StatefulIcon.h"
-
 #include "Icon.h"
+
+#include "../Graphics/Texture.h"
 
 namespace ms
 {
@@ -30,7 +31,10 @@ namespace ms
 		state = Icon::State::NORMAL;
 	}
 
-	Texture StatefulIcon::get_texture() const override
+	StatefulIcon::StatefulIcon() : StatefulIcon(std::make_unique<NullType>(), {}, {}, {}) {};
+	StatefulIcon::StatefulIcon();
+
+	Texture StatefulIcon::get_texture() const
 	{
 		return textures[state]
 	}

--- a/IO/Components/StatefulIcon.cpp
+++ b/IO/Components/StatefulIcon.cpp
@@ -31,16 +31,15 @@ namespace ms
 		state = Icon::State::NORMAL;
 	}
 
-	StatefulIcon::StatefulIcon() : StatefulIcon(std::make_unique<NullType>(), {}, {}, {}) {};
-	StatefulIcon::StatefulIcon();
+	StatefulIcon::StatefulIcon() : StatefulIcon(std::make_unique<Icon::NullType>(), {}, {}, {}) {};
 
 	Texture StatefulIcon::get_texture() const
 	{
-		return textures[state]
+		return textures[state];
 	}
 
-	void StatefulIcon::set_state(Icon::State)
+	void StatefulIcon::set_state(Icon::State s)
 	{
-		state = s
+		state = s;
 	}
 }

--- a/IO/Components/StatefulIcon.cpp
+++ b/IO/Components/StatefulIcon.cpp
@@ -1,0 +1,42 @@
+//////////////////////////////////////////////////////////////////////////////////
+//	This file is part of the continued Journey MMORPG client					//
+//	Copyright (C) 2015-2019  Daniel Allendorf, Ryan Payton						//
+//																				//
+//	This program is free software: you can redistribute it and/or modify		//
+//	it under the terms of the GNU Affero General Public License as published by	//
+//	the Free Software Foundation, either version 3 of the License, or			//
+//	(at your option) any later version.											//
+//																				//
+//	This program is distributed in the hope that it will be useful,				//
+//	but WITHOUT ANY WARRANTY; without even the implied warranty of				//
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the				//
+//	GNU Affero General Public License for more details.							//
+//																				//
+//	You should have received a copy of the GNU Affero General Public License	//
+//	along with this program.  If not, see <https://www.gnu.org/licenses/>.		//
+//////////////////////////////////////////////////////////////////////////////////
+#include "StatefulIcon.h"
+
+#include "Icon.h"
+
+namespace ms
+{
+	StatefulIcon::StatefulIcon(std::unique_ptr<Icon::Type> type, Texture ntx, Texture dtx, Texture motx) : Icon(type, ntx, count(-1))
+	{
+		dtx.shift({ 0, 32 });
+		motx.shift({ 0, 32 });
+		textures[Icon::State::DISABLED] = dtx;
+		textures[Icon::State::MOUSEOVER] = motx;
+		state = Icon::State::NORMAL;
+	}
+
+	Texture StatefulIcon::get_texture() const override
+	{
+		return textures[state]
+	}
+
+	void StatefulIcon::set_state(Icon::State)
+	{
+		state = s
+	}
+}

--- a/IO/Components/StatefulIcon.cpp
+++ b/IO/Components/StatefulIcon.cpp
@@ -22,7 +22,7 @@
 
 namespace ms
 {
-	StatefulIcon::StatefulIcon(std::unique_ptr<Icon::Type> type, Texture ntx, Texture dtx, Texture motx) : Icon(type, ntx, count(-1))
+	StatefulIcon::StatefulIcon(std::unique_ptr<Type> type, Texture ntx, Texture dtx, Texture motx) : Icon(type, ntx, count(-1))
 	{
 		dtx.shift({ 0, 32 });
 		motx.shift({ 0, 32 });
@@ -31,7 +31,7 @@ namespace ms
 		state = Icon::State::NORMAL;
 	}
 
-	StatefulIcon::StatefulIcon() : StatefulIcon(std::make_unique<Icon::NullType>(), {}, {}, {}) {};
+	StatefulIcon::StatefulIcon() : StatefulIcon(std::make_unique<NullType>(), {}, {}, {}) {};
 
 	Texture StatefulIcon::get_texture() const
 	{

--- a/IO/Components/StatefulIcon.cpp
+++ b/IO/Components/StatefulIcon.cpp
@@ -24,11 +24,14 @@ namespace ms
 {
 	StatefulIcon::StatefulIcon(std::unique_ptr<Type> type, Texture ntx, Texture dtx, Texture motx) : Icon(std::move(type), ntx, -1)
 	{
+		ntx.shift({ 0, 32 });
 		dtx.shift({ 0, 32 });
 		motx.shift({ 0, 32 });
-		textures[Icon::State::DISABLED] = dtx;
-		textures[Icon::State::MOUSEOVER] = motx;
-		state = Icon::State::NORMAL;
+		textures[State::NORMAL] = ntx;
+		textures[State::DISABLED] = dtx;
+		textures[State::MOUSEOVER] = motx;
+
+		state = State::NORMAL;
 	}
 
 	StatefulIcon::StatefulIcon() : StatefulIcon(std::make_unique<NullType>(), {}, {}, {}) {};
@@ -38,7 +41,7 @@ namespace ms
 		return textures[state];
 	}
 
-	void StatefulIcon::set_state(Icon::State s)
+	void StatefulIcon::set_state(State s)
 	{
 		state = s;
 	}

--- a/IO/Components/StatefulIcon.h
+++ b/IO/Components/StatefulIcon.h
@@ -26,15 +26,11 @@ namespace ms
 	class StatefulIcon : public Icon
 	{
 	public:
-		class Type
+		class Type : public Icon::Type
 		{
 		public:
 			virtual ~Type() {}
 
-			virtual void drop_on_stage() const = 0;
-			virtual void drop_on_equips(Equipslot::Id eqslot) const = 0;
-			virtual bool drop_on_items(InventoryType::Id tab, Equipslot::Id eqslot, int16_t slot, bool equip) const = 0;
-			virtual void drop_on_bindings(Point<int16_t> cursorposition, bool remove) const = 0;
 			virtual void set_state(Icon::State state) = 0;
 		};
 
@@ -44,6 +40,7 @@ namespace ms
 			void drop_on_equips(Equipslot::Id) const override {}
 			bool drop_on_items(InventoryType::Id, Equipslot::Id, int16_t, bool) const override { return true; }
 			void drop_on_bindings(Point<int16_t> cursorposition, bool remove) const override {}
+			void set_count(int16_t) override {}
 			void set_state(Icon::State state) override {};
 		};
 

--- a/IO/Components/StatefulIcon.h
+++ b/IO/Components/StatefulIcon.h
@@ -31,7 +31,7 @@ namespace ms
 			NORMAL = 0,
 			DISABLED,
 			MOUSEOVER,
-			LENGTH  // requirement for EnumMap
+			LENGTH
 		};
 
 		class Type : public Icon::Type

--- a/IO/Components/StatefulIcon.h
+++ b/IO/Components/StatefulIcon.h
@@ -1,0 +1,35 @@
+//////////////////////////////////////////////////////////////////////////////////
+//	This file is part of the continued Journey MMORPG client					//
+//	Copyright (C) 2015-2019  Daniel Allendorf, Ryan Payton						//
+//																				//
+//	This program is free software: you can redistribute it and/or modify		//
+//	it under the terms of the GNU Affero General Public License as published by	//
+//	the Free Software Foundation, either version 3 of the License, or			//
+//	(at your option) any later version.											//
+//																				//
+//	This program is distributed in the hope that it will be useful,				//
+//	but WITHOUT ANY WARRANTY; without even the implied warranty of				//
+//	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the				//
+//	GNU Affero General Public License for more details.							//
+//																				//
+//	You should have received a copy of the GNU Affero General Public License	//
+//	along with this program.  If not, see <https://www.gnu.org/licenses/>.		//
+//////////////////////////////////////////////////////////////////////////////////
+#pragma once
+
+#include "Icon.h"
+
+namespace ms
+{
+	class StatefulIcon : public Icon
+	{
+	public:
+		StatefulIcon(std::unique_ptr<Icon::Type> type, Texture normal_tx, Texture disabled_tx, Texture mouseover_tx);
+
+		Texture get_texture() const override;
+
+		void set_state(Icon::State state);
+	private:
+		Icon::State state;
+	};
+}

--- a/IO/Components/StatefulIcon.h
+++ b/IO/Components/StatefulIcon.h
@@ -26,12 +26,20 @@ namespace ms
 	class StatefulIcon : public Icon
 	{
 	public:
+		enum State: uint8_t
+		{
+			NORMAL = 0,
+			DISABLED,
+			MOUSEOVER,
+			LENGTH  // requirement for EnumMap
+		};
+
 		class Type : public Icon::Type
 		{
 		public:
 			virtual ~Type() {}
 
-			virtual void set_state(Icon::State state) = 0;
+			virtual void set_state(State state) = 0;
 		};
 
 		class NullType : public Type
@@ -41,7 +49,7 @@ namespace ms
 			bool drop_on_items(InventoryType::Id, Equipslot::Id, int16_t, bool) const override { return true; }
 			void drop_on_bindings(Point<int16_t> cursorposition, bool remove) const override {}
 			void set_count(int16_t) override {}
-			void set_state(Icon::State state) override {};
+			void set_state(State state) override {};
 		};
 
 		StatefulIcon(std::unique_ptr<Type> type, Texture normal_tx, Texture disabled_tx, Texture mouseover_tx);
@@ -49,8 +57,10 @@ namespace ms
 
 		Texture get_texture() const override;
 
-		void set_state(Icon::State state);
+		void set_state(State state);
+
 	private:
-		Icon::State state;
+		State state;
+		EnumMap<State, Texture> textures;
 	};
 }

--- a/IO/Components/StatefulIcon.h
+++ b/IO/Components/StatefulIcon.h
@@ -27,6 +27,7 @@ namespace ms
 	{
 	public:
 		StatefulIcon(std::unique_ptr<Icon::Type> type, Texture normal_tx, Texture disabled_tx, Texture mouseover_tx);
+		StatefulIcon();
 
 		Texture get_texture() const override;
 

--- a/IO/Components/StatefulIcon.h
+++ b/IO/Components/StatefulIcon.h
@@ -26,7 +26,28 @@ namespace ms
 	class StatefulIcon : public Icon
 	{
 	public:
-		StatefulIcon(std::unique_ptr<Icon::Type> type, Texture normal_tx, Texture disabled_tx, Texture mouseover_tx);
+		class Type
+		{
+		public:
+			virtual ~Type() {}
+
+			virtual void drop_on_stage() const = 0;
+			virtual void drop_on_equips(Equipslot::Id eqslot) const = 0;
+			virtual bool drop_on_items(InventoryType::Id tab, Equipslot::Id eqslot, int16_t slot, bool equip) const = 0;
+			virtual void drop_on_bindings(Point<int16_t> cursorposition, bool remove) const = 0;
+			virtual void set_state(Icon::State state) = 0;
+		};
+
+		class NullType : public Type
+		{
+			void drop_on_stage() const override {}
+			void drop_on_equips(Equipslot::Id) const override {}
+			bool drop_on_items(InventoryType::Id, Equipslot::Id, int16_t, bool) const override { return true; }
+			void drop_on_bindings(Point<int16_t> cursorposition, bool remove) const override {}
+			void set_state(Icon::State state) override {};
+		};
+
+		StatefulIcon(std::unique_ptr<Type> type, Texture normal_tx, Texture disabled_tx, Texture mouseover_tx);
 		StatefulIcon();
 
 		Texture get_texture() const override;

--- a/IO/Components/StatefulIcon.h
+++ b/IO/Components/StatefulIcon.h
@@ -19,6 +19,8 @@
 
 #include "Icon.h"
 
+#include "../Graphics/Texture.h"
+
 namespace ms
 {
 	class StatefulIcon : public Icon

--- a/IO/UITypes/UISkillbook.cpp
+++ b/IO/UITypes/UISkillbook.cpp
@@ -36,7 +36,7 @@ namespace ms
 
 	void UISkillbook::SkillIcon::drop_on_bindings(Point<int16_t> cursorposition, bool remove) const
 	{
-		// TODO
+		// TODO: Implement this
 	}
 
 	UISkillbook::SkillDisplayMeta::SkillDisplayMeta(int32_t i, int32_t l) : id(i), level(l)
@@ -490,7 +490,7 @@ namespace ms
 					}
 					else
 					{
-						skills[i].get_icon()->set_state(StatefulIcon::MOUSEOVER);
+						skills[i].get_icon()->set_state(StatefulIcon::State::MOUSEOVER);
 						show_skill(skills[i].get_id());
 
 						return Cursor::State::IDLE;
@@ -506,7 +506,7 @@ namespace ms
 
 			for (size_t i = 0; i < skills.size(); i++)
 			{
-				skills[i].get_icon()->set_state(StatefulIcon::NORMAL);
+				skills[i].get_icon()->set_state(StatefulIcon::State::NORMAL);
 			}
 			clear_tooltip();
 		}

--- a/IO/UITypes/UISkillbook.cpp
+++ b/IO/UITypes/UISkillbook.cpp
@@ -68,10 +68,9 @@ namespace ms
 
 	void UISkillbook::SkillDisplayMeta::draw(const DrawArgument& args) const
 	{
-		// TODO adjust "ICON_OFFSET" and rename to SKILL_META_OFFSET
-		icon->draw(args.getpos() - Point<int16_t>(0, 32));
-		name_text.draw(args + Point<int16_t>(38, -37));
-		level_text.draw(args + Point<int16_t>(38, -19));
+		icon->draw(args.getpos());
+		name_text.draw(args + Point<int16_t>(38, -5));
+		level_text.draw(args + Point<int16_t>(38, 13));
 	}
 
 	int32_t UISkillbook::SkillDisplayMeta::get_id() const
@@ -231,7 +230,7 @@ namespace ms
 					skills[i].get_icon()->set_state(StatefulIcon::State::DISABLED);
 				}
 
-				skills[i].draw(pos + ICON_OFFSET);
+				skills[i].draw(pos + SKILL_META_OFFSET);
 			}
 			else
 			{
@@ -479,7 +478,6 @@ namespace ms
 
 						if (skill_level > 0 && !SkillData::get(skill_id).is_passive())
 						{
-							// TODO refine this
 							skills[i].get_icon()->start_drag(cursorpos - skill_position);
 							UI::get().drag_icon(skills[i].get_icon());
 
@@ -514,7 +512,6 @@ namespace ms
 		}
 		else
 		{
-			// TODO this looks correct in the client, but is this logic actually correct? -- look into UIDragElement
 			grabbing = false;
 		}
 

--- a/IO/UITypes/UISkillbook.cpp
+++ b/IO/UITypes/UISkillbook.cpp
@@ -228,7 +228,7 @@ namespace ms
 				else
 				{
 					skilld.draw(pos);
-					skills[i].get_icon()->set_state(Icon::State::DISABLED);
+					skills[i].get_icon()->set_state(StatefulIcon::State::DISABLED);
 				}
 
 				skills[i].draw(pos + ICON_OFFSET);

--- a/IO/UITypes/UISkillbook.cpp
+++ b/IO/UITypes/UISkillbook.cpp
@@ -17,8 +17,8 @@
 //////////////////////////////////////////////////////////////////////////////////
 #include "UISkillbook.h"
 
-#include "../Components/MapleButton.h"
 #include "../Components/Icon.h"
+#include "../Components/MapleButton.h"
 #include "../Components/StatefulIcon.h"
 #include "../Character/SkillId.h"
 #include "../Data/JobData.h"
@@ -756,7 +756,7 @@ namespace ms
 		}
 	}
 
-	UISkillbook::SkillDisplayMeta* UISkillbook::skill_by_position(Point<int16_t> cursorpos)
+	UISkillbook::SkillDisplayMeta* UISkillbook::skill_by_position(Point<int16_t> cursorpos) const
 	{
 		int16_t x = cursorpos.x();
 

--- a/IO/UITypes/UISkillbook.cpp
+++ b/IO/UITypes/UISkillbook.cpp
@@ -28,7 +28,6 @@
 
 #include "../Net/Packets/PlayerPackets.h"
 
-#include <memory>
 #include <nlnx/nx.hpp>
 
 namespace ms
@@ -69,7 +68,8 @@ namespace ms
 
 	void UISkillbook::SkillDisplayMeta::draw(const DrawArgument& args) const
 	{
-		icon->draw(args.getpos());
+		// TODO adjust "ICON_OFFSET" and rename to SKILL_META_OFFSET
+		icon->draw(args.getpos() - Point<int16_t>(0, 32));
 		name_text.draw(args + Point<int16_t>(38, -37));
 		level_text.draw(args + Point<int16_t>(38, -19));
 	}
@@ -474,7 +474,20 @@ namespace ms
 						clear_tooltip();
 						grabbing = true;
 
-						return Cursor::State::GRABBING;
+						int32_t skill_id = skills[i].get_id();
+						int32_t skill_level = skillbook.get_level(skill_id);
+
+						if (skill_level > 0 && !SkillData::get(skill_id).is_passive()) {
+							// TODO refine this
+							skills[i].get_icon()->start_drag(cursorpos - skill_position);
+							UI::get().drag_icon(skills[i].get_icon());
+
+							return Cursor::State::GRABBING;
+						}
+						else
+						{
+							return Cursor::State::IDLE;
+						}
 					}
 					else
 					{
@@ -495,10 +508,8 @@ namespace ms
 		}
 		else
 		{
-			if (clicked)
-				grabbing = false;
-			else
-				return Cursor::State::GRABBING;
+			// TODO this looks correct in the client, but is this logic actually correct? -- look into UIDragElement
+			grabbing = false;
 		}
 
 		return UIElement::send_cursor(clicked, cursorpos);

--- a/IO/UITypes/UISkillbook.cpp
+++ b/IO/UITypes/UISkillbook.cpp
@@ -67,6 +67,13 @@ namespace ms
 		}
 	}
 
+	void UISkillbook::SkillDisplayMeta::draw(const DrawArgument& args) const
+	{
+		icon->draw(args.getpos());
+		name_text.draw(args + Point<int16_t>(38, -37));
+		level_text.draw(args + Point<int16_t>(38, -19));
+	}
+
 	int32_t UISkillbook::SkillDisplayMeta::get_id() const
 	{
 		return id;
@@ -224,7 +231,7 @@ namespace ms
 					skills[i].get_icon()->set_state(Icon::State::DISABLED);
 				}
 
-				skills[i].get_icon()->draw(pos + ICON_OFFSET);
+				skills[i].draw(pos + ICON_OFFSET);
 			}
 			else
 			{
@@ -749,7 +756,7 @@ namespace ms
 		}
 	}
 
-	UISkillbook::SkillDisplayMeta* UISkillbook::skill_by_position(Point<int16_t> cursorpos) const
+	UISkillbook::SkillDisplayMeta* UISkillbook::skill_by_position(Point<int16_t> cursorpos)
 	{
 		int16_t x = cursorpos.x();
 

--- a/IO/UITypes/UISkillbook.cpp
+++ b/IO/UITypes/UISkillbook.cpp
@@ -477,7 +477,8 @@ namespace ms
 						int32_t skill_id = skills[i].get_id();
 						int32_t skill_level = skillbook.get_level(skill_id);
 
-						if (skill_level > 0 && !SkillData::get(skill_id).is_passive()) {
+						if (skill_level > 0 && !SkillData::get(skill_id).is_passive())
+						{
 							// TODO refine this
 							skills[i].get_icon()->start_drag(cursorpos - skill_position);
 							UI::get().drag_icon(skills[i].get_icon());
@@ -491,6 +492,7 @@ namespace ms
 					}
 					else
 					{
+						skills[i].get_icon()->set_state(StatefulIcon::MOUSEOVER);
 						show_skill(skills[i].get_id());
 
 						return Cursor::State::IDLE;
@@ -504,6 +506,10 @@ namespace ms
 				}
 			}
 
+			for (size_t i = 0; i < skills.size(); i++)
+			{
+				skills[i].get_icon()->set_state(StatefulIcon::NORMAL);
+			}
 			clear_tooltip();
 		}
 		else

--- a/IO/UITypes/UISkillbook.h
+++ b/IO/UITypes/UISkillbook.h
@@ -27,8 +27,6 @@
 #include "../Character/Skillbook.h"
 #include "../Graphics/Text.h"
 
-#include <memory>
-
 namespace ms
 {
 	class UISkillbook : public UIDragElement<PosSKILL>
@@ -65,6 +63,7 @@ namespace ms
 			void drop_on_equips(Equipslot::Id) const override {}
 			bool drop_on_items(InventoryType::Id, Equipslot::Id, int16_t, bool) const override { return true; }
 			void drop_on_bindings(Point<int16_t> cursorposition, bool remove) const override;
+			void set_count(int16_t) override {}
 			void set_state(Icon::State state) override {};
 
 		private:

--- a/IO/UITypes/UISkillbook.h
+++ b/IO/UITypes/UISkillbook.h
@@ -27,6 +27,8 @@
 #include "../Character/Skillbook.h"
 #include "../Graphics/Text.h"
 
+#include <memory>
+
 namespace ms
 {
 	class UISkillbook : public UIDragElement<PosSKILL>
@@ -54,6 +56,38 @@ namespace ms
 		Button::State button_pressed(uint16_t id) override;
 
 	private:
+		class SkillIcon : public StatefulIcon::Type
+		{
+		public:
+			SkillIcon(int32_t skill_id);
+
+			void drop_on_stage() const override {}
+			void drop_on_equips(Equipslot::Id) const override {}
+			bool drop_on_items(InventoryType::Id, Equipslot::Id, int16_t, bool) const override { return true; }
+			void drop_on_bindings(Point<int16_t> cursorposition, bool remove) const override;
+			void set_count(int16_t) override {}
+
+		private:
+			int32_t skill_id;
+		};
+
+		class SkillDisplayMeta
+		{
+		public:
+			SkillDisplayMeta(int32_t id, int32_t level);
+
+			int32_t get_id() const;
+			int32_t get_level() const;
+			StatefulIcon* get_icon() const;
+
+		private:
+			int32_t id;
+			int32_t level;
+			std::unique_ptr<StatefulIcon> icon;
+			Text name_text;
+			Text level_text;
+		};
+
 		void change_job(uint16_t id);
 		void change_sp();
 		void change_tab(uint16_t new_tab);
@@ -67,7 +101,7 @@ namespace ms
 		void spend_sp(int32_t skill_id);
 
 		Job::Level joblevel_by_tab(uint16_t tab) const;
-		SkillIconDeprecated* icon_by_position(Point<int16_t> cursorpos);
+		UISkillbook::SkillDisplayMeta* skill_by_position(Point<int16_t> cursorpos) const;
 
 		void close();
 		bool check_required(int32_t id) const;
@@ -134,7 +168,7 @@ namespace ms
 		uint16_t skillcount;
 		uint16_t offset;
 
-		std::vector<SkillIconDeprecated> icons;
+		std::vector<SkillDisplayMeta> skills;
 		bool grabbing;
 
 		Point<int16_t> bg_dimensions;
@@ -158,37 +192,5 @@ namespace ms
 		Texture sp_skill;
 		int32_t sp_id;
 		int32_t sp_masterlevel;
-
-		class SkillIcon : public StatefulIcon::Type
-		{
-		public:
-			SkillIcon(int32_t skill_id);
-
-			void drop_on_stage() const override {}
-			void drop_on_equips(Equipslot::Id) const override {}
-			bool drop_on_items(InventoryType::Id, Equipslot::Id, int16_t, bool) const override { return true; }
-			void drop_on_bindings(Point<int16_t> cursorposition, bool remove) const override;
-			void set_count(int16_t) override {}
-
-		private:
-			int32_t skill_id;
-		};
-
-		class SkillMeta
-		{
-		public:
-			SkillMeta(int32_t id, int32_t level);
-
-			int32_t get_id() const;
-			int32_t get_level() const;
-			UISkillbook::SkillIcon get_icon() const;
-
-		private:
-			int32_t id;
-			int32_t level;
-			UISkillbook::SkillIcon icon;
-			Text name_text;
-			Text level_text;
-		};
 	};
 }

--- a/IO/UITypes/UISkillbook.h
+++ b/IO/UITypes/UISkillbook.h
@@ -76,6 +76,8 @@ namespace ms
 		public:
 			SkillDisplayMeta(int32_t id, int32_t level);
 
+			void draw(const DrawArgument& args) const;
+
 			int32_t get_id() const;
 			int32_t get_level() const;
 			StatefulIcon* get_icon() const;
@@ -101,7 +103,7 @@ namespace ms
 		void spend_sp(int32_t skill_id);
 
 		Job::Level joblevel_by_tab(uint16_t tab) const;
-		UISkillbook::SkillDisplayMeta* skill_by_position(Point<int16_t> cursorpos) const;
+		UISkillbook::SkillDisplayMeta* skill_by_position(Point<int16_t> cursorpos);
 
 		void close();
 		bool check_required(int32_t id) const;

--- a/IO/UITypes/UISkillbook.h
+++ b/IO/UITypes/UISkillbook.h
@@ -146,7 +146,7 @@ namespace ms
 		static constexpr int16_t ROW_HEIGHT = 40;
 		static constexpr int16_t ROW_WIDTH = 143;
 		static constexpr Point<int16_t> SKILL_OFFSET = Point<int16_t>(11, 93);
-		static constexpr Point<int16_t> ICON_OFFSET = Point<int16_t>(2, 34);
+		static constexpr Point<int16_t> SKILL_META_OFFSET = Point<int16_t>(2, 2);
 		static constexpr Point<int16_t> LINE_OFFSET = Point<int16_t>(0, 37);
 
 		const CharStats& stats;

--- a/IO/UITypes/UISkillbook.h
+++ b/IO/UITypes/UISkillbook.h
@@ -22,45 +22,13 @@
 
 #include "../Components/Slider.h"
 #include "../Components/Charset.h"
+#include "../Components/StatefulIcon.h"
 #include "../Character/CharStats.h"
 #include "../Character/Skillbook.h"
 #include "../Graphics/Text.h"
 
 namespace ms
 {
-	class SkillIcon
-	{
-	public:
-		SkillIcon(int32_t id, int32_t level);
-
-		void draw(const DrawArgument& args) const;
-
-		enum State
-		{
-			NORMAL,
-			DISABLED,
-			MOUSEOVER
-		};
-
-		void set_state(State state);
-
-		int32_t get_id() const;
-		int32_t get_level() const;
-		Texture get_icon() const;
-
-	private:
-		Texture normal;
-		Texture disabled;
-		Texture mouseover;
-		Text name;
-		Text level;
-		int32_t id;
-		int32_t lv;
-
-		State state;
-		bool enabled;
-	};
-
 	class UISkillbook : public UIDragElement<PosSKILL>
 	{
 	public:
@@ -99,7 +67,7 @@ namespace ms
 		void spend_sp(int32_t skill_id);
 
 		Job::Level joblevel_by_tab(uint16_t tab) const;
-		SkillIcon* icon_by_position(Point<int16_t> cursorpos);
+		SkillIconDeprecated* icon_by_position(Point<int16_t> cursorpos);
 
 		void close();
 		bool check_required(int32_t id) const;
@@ -166,7 +134,7 @@ namespace ms
 		uint16_t skillcount;
 		uint16_t offset;
 
-		std::vector<SkillIcon> icons;
+		std::vector<SkillIconDeprecated> icons;
 		bool grabbing;
 
 		Point<int16_t> bg_dimensions;
@@ -190,5 +158,37 @@ namespace ms
 		Texture sp_skill;
 		int32_t sp_id;
 		int32_t sp_masterlevel;
+
+		class SkillIcon : public StatefulIcon::Type
+		{
+		public:
+			SkillIcon(int32_t skill_id);
+
+			void drop_on_stage() const override {}
+			void drop_on_equips(Equipslot::Id) const override {}
+			bool drop_on_items(InventoryType::Id, Equipslot::Id, int16_t, bool) const override { return true; }
+			void drop_on_bindings(Point<int16_t> cursorposition, bool remove) const override;
+			void set_count(int16_t) override {}
+
+		private:
+			int32_t skill_id;
+		};
+
+		class SkillMeta
+		{
+		public:
+			SkillMeta(int32_t id, int32_t level);
+
+			int32_t get_id() const;
+			int32_t get_level() const;
+			UISkillbook::SkillIcon get_icon() const;
+
+		private:
+			int32_t id;
+			int32_t level;
+			UISkillbook::SkillIcon icon;
+			Text name_text;
+			Text level_text;
+		};
 	};
 }

--- a/IO/UITypes/UISkillbook.h
+++ b/IO/UITypes/UISkillbook.h
@@ -64,7 +64,7 @@ namespace ms
 			bool drop_on_items(InventoryType::Id, Equipslot::Id, int16_t, bool) const override { return true; }
 			void drop_on_bindings(Point<int16_t> cursorposition, bool remove) const override;
 			void set_count(int16_t) override {}
-			void set_state(Icon::State state) override {};
+			void set_state(StatefulIcon::State state) override {};
 
 		private:
 			int32_t skill_id;

--- a/IO/UITypes/UISkillbook.h
+++ b/IO/UITypes/UISkillbook.h
@@ -65,7 +65,7 @@ namespace ms
 			void drop_on_equips(Equipslot::Id) const override {}
 			bool drop_on_items(InventoryType::Id, Equipslot::Id, int16_t, bool) const override { return true; }
 			void drop_on_bindings(Point<int16_t> cursorposition, bool remove) const override;
-			void set_count(int16_t) override {}
+			void set_state(Icon::State state) override {};
 
 		private:
 			int32_t skill_id;
@@ -103,7 +103,7 @@ namespace ms
 		void spend_sp(int32_t skill_id);
 
 		Job::Level joblevel_by_tab(uint16_t tab) const;
-		UISkillbook::SkillDisplayMeta* skill_by_position(Point<int16_t> cursorpos);
+		UISkillbook::SkillDisplayMeta* skill_by_position(Point<int16_t> cursorpos) const;
 
 		void close();
 		bool check_required(int32_t id) const;

--- a/MapleStory.vcxproj
+++ b/MapleStory.vcxproj
@@ -234,6 +234,7 @@ copy /y /d  "$(ProjectDir)includes\nlnx\includes\lz4_v1_8_2_win64\dll\liblz4.so.
     <ClCompile Include="io\components\ScrollingNotice.cpp" />
     <ClCompile Include="io\components\SkillTooltip.cpp" />
     <ClCompile Include="io\components\Slider.cpp" />
+    <ClCompile Include="IO\Components\StatefulIcon.cpp" />
     <ClCompile Include="io\components\Textfield.cpp" />
     <ClCompile Include="IO\Components\TextTooltip.cpp" />
     <ClCompile Include="io\components\TwoSpriteButton.cpp" />
@@ -425,6 +426,7 @@ copy /y /d  "$(ProjectDir)includes\nlnx\includes\lz4_v1_8_2_win64\dll\liblz4.so.
     <ClInclude Include="io\components\ScrollingNotice.h" />
     <ClInclude Include="io\components\SkillTooltip.h" />
     <ClInclude Include="io\components\Slider.h" />
+    <ClInclude Include="IO\Components\StatefulIcon.h" />
     <ClInclude Include="io\components\Textfield.h" />
     <ClInclude Include="IO\Components\TextTooltip.h" />
     <ClInclude Include="io\components\Tooltip.h" />

--- a/MapleStory.vcxproj
+++ b/MapleStory.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -234,7 +234,6 @@ copy /y /d  "$(ProjectDir)includes\nlnx\includes\lz4_v1_8_2_win64\dll\liblz4.so.
     <ClCompile Include="io\components\ScrollingNotice.cpp" />
     <ClCompile Include="io\components\SkillTooltip.cpp" />
     <ClCompile Include="io\components\Slider.cpp" />
-    <ClCompile Include="IO\Components\StatefulIcon.cpp" />
     <ClCompile Include="io\components\Textfield.cpp" />
     <ClCompile Include="IO\Components\TextTooltip.cpp" />
     <ClCompile Include="io\components\TwoSpriteButton.cpp" />
@@ -426,7 +425,6 @@ copy /y /d  "$(ProjectDir)includes\nlnx\includes\lz4_v1_8_2_win64\dll\liblz4.so.
     <ClInclude Include="io\components\ScrollingNotice.h" />
     <ClInclude Include="io\components\SkillTooltip.h" />
     <ClInclude Include="io\components\Slider.h" />
-    <ClInclude Include="IO\Components\StatefulIcon.h" />
     <ClInclude Include="io\components\Textfield.h" />
     <ClInclude Include="IO\Components\TextTooltip.h" />
     <ClInclude Include="io\components\Tooltip.h" />
@@ -532,7 +530,6 @@ copy /y /d  "$(ProjectDir)includes\nlnx\includes\lz4_v1_8_2_win64\dll\liblz4.so.
     <ClInclude Include="template\TimedQueue.h" />
     <ClInclude Include="template\TypeMap.h" />
     <ClInclude Include="Timer.h" />
-    <ClInclude Include="UIKeyIcon.h" />
     <ClInclude Include="Util\HardwareInfo.h" />
     <ClInclude Include="util\HashUtility.h" />
     <ClInclude Include="util\Lerp.h" />

--- a/MapleStory.vcxproj
+++ b/MapleStory.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -234,6 +234,7 @@ copy /y /d  "$(ProjectDir)includes\nlnx\includes\lz4_v1_8_2_win64\dll\liblz4.so.
     <ClCompile Include="io\components\ScrollingNotice.cpp" />
     <ClCompile Include="io\components\SkillTooltip.cpp" />
     <ClCompile Include="io\components\Slider.cpp" />
+    <ClCompile Include="IO\Components\StatefulIcon.cpp" />
     <ClCompile Include="io\components\Textfield.cpp" />
     <ClCompile Include="IO\Components\TextTooltip.cpp" />
     <ClCompile Include="io\components\TwoSpriteButton.cpp" />
@@ -425,6 +426,7 @@ copy /y /d  "$(ProjectDir)includes\nlnx\includes\lz4_v1_8_2_win64\dll\liblz4.so.
     <ClInclude Include="io\components\ScrollingNotice.h" />
     <ClInclude Include="io\components\SkillTooltip.h" />
     <ClInclude Include="io\components\Slider.h" />
+    <ClInclude Include="IO\Components\StatefulIcon.h" />
     <ClInclude Include="io\components\Textfield.h" />
     <ClInclude Include="IO\Components\TextTooltip.h" />
     <ClInclude Include="io\components\Tooltip.h" />
@@ -530,6 +532,7 @@ copy /y /d  "$(ProjectDir)includes\nlnx\includes\lz4_v1_8_2_win64\dll\liblz4.so.
     <ClInclude Include="template\TimedQueue.h" />
     <ClInclude Include="template\TypeMap.h" />
     <ClInclude Include="Timer.h" />
+    <ClInclude Include="UIKeyIcon.h" />
     <ClInclude Include="Util\HardwareInfo.h" />
     <ClInclude Include="util\HashUtility.h" />
     <ClInclude Include="util\Lerp.h" />

--- a/MapleStory.vcxproj.filters
+++ b/MapleStory.vcxproj.filters
@@ -546,6 +546,9 @@
     <ClCompile Include="Gameplay\Maplemap\MapEffect.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="IO\Components\StatefulIcon.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Configuration.h">
@@ -1239,6 +1242,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Gameplay\Maplemap\MapEffect.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="UIKeyIcon.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IO\Components\StatefulIcon.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/MapleStory.vcxproj.filters
+++ b/MapleStory.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -544,6 +544,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Gameplay\Maplemap\MapEffect.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="IO\Components\StatefulIcon.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
@@ -1239,6 +1242,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Gameplay\Maplemap\MapEffect.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="IO\Components\StatefulIcon.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/MapleStory.vcxproj.filters
+++ b/MapleStory.vcxproj.filters
@@ -546,9 +546,6 @@
     <ClCompile Include="Gameplay\Maplemap\MapEffect.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="IO\Components\StatefulIcon.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Configuration.h">
@@ -1242,12 +1239,6 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Gameplay\Maplemap\MapEffect.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="UIKeyIcon.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="IO\Components\StatefulIcon.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Basic outline of how I imagine we could refactor UISkillbook to use IO/Components/Icon.h. This is the first step in resolving  #17.

The original `SkillIcon` in `UISkillbook` did a lot more than just handle the icon and seemed a little monolithic. I split this up into `SkillIcon` (new) and `SkillDisplayMeta`.

* `StatefulIcon` was created to extend functionality in `Icon` that is used by other UIs in the codebase like UIKeyConfig, UIItemInventory, and UIEquipInventory. With the added feature of adding states to the icon on DISABLE and MOUSEOVER.
* `SkillIcon` (new) inherits from `StatefulIcon`
* `SkillDisplayMeta` is responsible for handling all visual components for displaying a skill in the UI, including the `SkillIcon` (new) for that skill.

`UISkillbook` then uses a Vector of `SkillDisplayMeta` instead of the old `SkillIcon` for displaying information in the skill rows.

Ultimately the logic in `SkillIcon` (new) will be completed to pass along skill information to `UIKeyConfig` for registering skills to the keyconfig.