### PR TITLE
Ghost monster fix

### DIFF
--- a/Gameplay/Stage.cpp
+++ b/Gameplay/Stage.cpp
@@ -54,7 +54,6 @@ namespace ms
 			break;
 		}
 		state = State::ACTIVE;
-		// PlayerMapTransferPacket().dispatch();
 	}
 
 	void Stage::loadplayer(const CharEntry& entry)

--- a/Gameplay/Stage.cpp
+++ b/Gameplay/Stage.cpp
@@ -53,6 +53,7 @@ namespace ms
 			respawn(portalid);
 			break;
 		}
+
 		state = State::ACTIVE;
 	}
 

--- a/Gameplay/Stage.cpp
+++ b/Gameplay/Stage.cpp
@@ -53,8 +53,8 @@ namespace ms
 			respawn(portalid);
 			break;
 		}
-
 		state = State::ACTIVE;
+		// PlayerMapTransferPacket().dispatch();
 	}
 
 	void Stage::loadplayer(const CharEntry& entry)
@@ -72,6 +72,8 @@ namespace ms
 		mobs.clear();
 		drops.clear();
 		reactors.clear();
+
+		PlayerMapTransferPacket().dispatch();
 	}
 
 	void Stage::load_map(int32_t mapid)
@@ -184,7 +186,6 @@ namespace ms
 		}
 		else if (warpinfo.valid)
 		{
-			PlayerMapTransferPacket().dispatch();
 			ChangeMapPacket(false, warpinfo.mapid, warpinfo.name, false).dispatch();
 
 			CharStats& stats = Stage::get().get_player().get_stats();


### PR DESCRIPTION
This is an initial fix for the ghost monsters issue. Taking hints from the localhost client, __PlayerMapTransferPacket__ was moved so that the packet is sent after __ChangeMapPacket__. In order to send the __PlayerMapTransferPacket__ at every map change, including dying and GM commands, it was added to **Stage::clear()**.

Let me know if there are any issues remaining, or new ones caused by this patch.