### PR TITLE
Enable items in keyconfig

### DIFF
--- a/IO/UITypes/UIItemInventory.cpp
+++ b/IO/UITypes/UIItemInventory.cpp
@@ -28,6 +28,7 @@
 #include "../Gameplay/Stage.h"
 #include "../Data/EquipData.h"
 
+#include "../IO/UITypes/UIKeyConfig.h"
 #include "../Net/Packets/InventoryPackets.h"
 
 #include <nlnx/nx.hpp>
@@ -235,7 +236,7 @@ namespace ms
 			Equipslot::Id eqslot = inventory.find_equipslot(item_id);
 
 			icons[slot] = std::make_unique<Icon>(
-				std::make_unique<ItemIcon>(*this, tab, eqslot, slot, count, untradable, cashitem),
+				std::make_unique<ItemIcon>(*this, tab, eqslot, slot, item_id, count, untradable, cashitem),
 				texture, count
 				);
 		}
@@ -855,11 +856,12 @@ namespace ms
 		count = c;
 	}
 
-	UIItemInventory::ItemIcon::ItemIcon(const UIItemInventory& parent, InventoryType::Id st, Equipslot::Id eqs, int16_t s, int16_t c, bool u, bool cash) : parent(parent)
+	UIItemInventory::ItemIcon::ItemIcon(const UIItemInventory& parent, InventoryType::Id st, Equipslot::Id eqs, int16_t s, int32_t iid, int16_t c, bool u, bool cash) : parent(parent)
 	{
 		sourcetab = st;
 		eqsource = eqs;
 		source = s;
+		item_id = iid;
 		count = c;
 		untradable = u;
 		cashitem = cash;
@@ -946,5 +948,19 @@ namespace ms
 		MoveItemPacket(tab, source, slot, 1).dispatch();
 
 		return true;
+	}
+
+	void UIItemInventory::ItemIcon::drop_on_bindings(Point<int16_t> cursorposition, bool remove) const
+	{
+		if (sourcetab == InventoryType::Id::USE || sourcetab == InventoryType::Id::SETUP)
+		{
+			auto keyconfig = UI::get().get_element<UIKeyConfig>();
+			Keyboard::Mapping mapping = Keyboard::Mapping(KeyType::ITEM, item_id);
+
+			if (remove)
+				keyconfig->unstage_mapping(mapping);
+			else
+				keyconfig->stage_mapping(cursorposition, mapping);
+		}
 	}
 }

--- a/IO/UITypes/UIItemInventory.h
+++ b/IO/UITypes/UIItemInventory.h
@@ -75,7 +75,7 @@ namespace ms
 
 			void drop_on_stage() const override;
 			void drop_on_equips(Equipslot::Id eqslot) const override;
-			bool drop_on_items(InventoryType::Id tab, Equipslot::Id, int16_t slot, bool) const override;
+			bool drop_on_items(InventoryType::Id tab, Equipslot::Id eqslot, int16_t slot, bool equip) const override;
 			void drop_on_bindings(Point<int16_t> cursorposition, bool remove) const override;
 			void set_count(int16_t count) override;
 

--- a/IO/UITypes/UIItemInventory.h
+++ b/IO/UITypes/UIItemInventory.h
@@ -71,18 +71,19 @@ namespace ms
 		class ItemIcon : public Icon::Type
 		{
 		public:
-			ItemIcon(const UIItemInventory& parent, InventoryType::Id sourcetab, Equipslot::Id eqsource, int16_t source, int16_t count, bool untradable, bool cashitem);
+			ItemIcon(const UIItemInventory& parent, InventoryType::Id sourcetab, Equipslot::Id eqsource, int16_t source, int32_t item_id, int16_t count, bool untradable, bool cashitem);
 
 			void drop_on_stage() const override;
 			void drop_on_equips(Equipslot::Id eqslot) const override;
 			bool drop_on_items(InventoryType::Id tab, Equipslot::Id, int16_t slot, bool) const override;
-			void drop_on_bindings(Point<int16_t>, bool) const override {}
+			void drop_on_bindings(Point<int16_t> cursorposition, bool remove) const override;
 			void set_count(int16_t count) override;
 
 		private:
 			InventoryType::Id sourcetab;
 			Equipslot::Id eqsource;
 			int16_t source;
+			int32_t item_id;
 			int16_t count;
 			bool untradable;
 			bool cashitem;

--- a/IO/UITypes/UIKeyConfig.h
+++ b/IO/UITypes/UIKeyConfig.h
@@ -57,6 +57,7 @@ namespace ms
 		void load_key_textures();
 		void load_action_mappings();
 		void load_action_icons();
+		void load_item_icons();
 		void load_skill_icons();
 
 		void safe_close();
@@ -66,6 +67,7 @@ namespace ms
 		void clear();
 		void reset();
 
+		Texture get_item_texture(int32_t item_id) const;
 		Texture get_skill_texture(int32_t skill_id) const;
 		KeyConfig::Key key_by_position(Point<int16_t> position) const;
 		KeyAction::Id unbound_action_by_position(Point<int16_t> position) const;
@@ -112,6 +114,7 @@ namespace ms
 		EnumMap<KeyAction::Id, std::unique_ptr<Icon>> action_icons;
 		EnumMap<KeyAction::Id, Point<int16_t>> unbound_actions_pos;
 
+		std::map<int32_t, std::unique_ptr<Icon>> item_icons;
 		std::map<int32_t, std::unique_ptr<Icon>> skill_icons;
 
 		// Used to determine if mapping belongs to predefined action, e.g. attack, pick up, faces, etc.

--- a/IO/UITypes/UISkillbook.cpp
+++ b/IO/UITypes/UISkillbook.cpp
@@ -28,6 +28,7 @@
 #include "../KeyType.h"
 #include "../IO/UI.h"
 
+#include "../IO/UITypes/UIKeyConfig.h"
 #include "../Net/Packets/PlayerPackets.h"
 
 #include <nlnx/nx.hpp>


### PR DESCRIPTION
Resolves issue #34.

This allows players to:
-  Drag USE and SETUP items from the item inventory onto keybindings
-  Remove items from keybindings by dropping them in the bottom actions tray or dragging them onto the stage
-  Save item keybindings to the server

![image](https://user-images.githubusercontent.com/58151192/71235277-b2b1f780-22c9-11ea-9177-47b7603913e5.png)

Known caveats (I will ticket these):
- total item counts aren't yet displayed on the keyconfig
- there is 0 delay between consuming potions, meaning it's extremely easy to accidentally use more than 1 (Arnah has some information on this in the chat)
- tooltips for items AND skills are not yet implemented in the keyconfig
- SETUP items do not yet seem to work in HeavenMS -- tested using The Relaxer (3010000)
- potions do not make a sound when consumed

Other caveats (I will ticket these):
- if I hover over an item in the inventory menu, and I move my cursor to another overlapping window, it will bring the item tooltip along with it