### PR TITLE
KeyConfig Tooltips (Fixes #56)

### DIFF
--- a/IO/Components/Tooltip.h
+++ b/IO/Components/Tooltip.h
@@ -37,7 +37,8 @@ namespace ms
 			SKILLBOOK,
 			SHOP,
 			EVENT,
-			TEXT
+			TEXT,
+			KEYCONFIG
 		};
 
 		virtual ~Tooltip() {}

--- a/IO/UIStateGame.cpp
+++ b/IO/UIStateGame.cpp
@@ -257,7 +257,9 @@ namespace ms
 						auto keyconfig = UI::get().get_element<UIKeyConfig>();
 
 						if (!keyconfig || !keyconfig->is_active())
-							emplace<UIKeyConfig>();
+							emplace<UIKeyConfig>(
+								Stage::get().get_player().get_skills()
+								);
 						else if (keyconfig && keyconfig->is_active())
 							keyconfig->close();
 

--- a/IO/UITypes/UIKeyConfig.cpp
+++ b/IO/UITypes/UIKeyConfig.cpp
@@ -512,7 +512,7 @@ namespace ms
 		}
 	}
 
-	// UI
+	// UI: General
 
 	void UIKeyConfig::draw(float inter) const
 	{
@@ -614,6 +614,7 @@ namespace ms
 
 	void UIKeyConfig::close()
 	{
+		clear_tooltip();
 		deactivate();
 		reset();
 	}
@@ -708,6 +709,8 @@ namespace ms
 			}
 		}
 
+		clear_tooltip();
+
 		KeyConfig::Key key_slot = key_by_position(cursorpos);
 
 		if (key_slot != KeyConfig::Key::LENGTH)
@@ -722,11 +725,15 @@ namespace ms
 				{
 					int32_t item_id = mapping.action;
 					ficon = item_icons[item_id].get();
+
+					show_item(item_id);
 				}
 				else if (mapping.type == KeyType::Id::SKILL)
 				{
 					int32_t skill_id = mapping.action;
 					ficon = skill_icons[skill_id].get();
+
+					show_skill(skill_id);
 				}
 				else if (is_action_mapping(mapping))
 				{
@@ -742,6 +749,8 @@ namespace ms
 				{
 					if (clicked)
 					{
+						clear_tooltip();
+
 						ficon->start_drag(cursorpos - position - keys_pos[key_slot]);
 						UI::get().drag_icon(ficon);
 
@@ -753,6 +762,10 @@ namespace ms
 					}
 				}
 			}
+		}
+		else
+		{
+			clear_tooltip();
 		}
 
 		return UIElement::send_cursor(clicked, cursorpos);
@@ -810,6 +823,28 @@ namespace ms
 		{
 			close();
 		}
+	}
+
+	// UI: Tooltip
+
+	void UIKeyConfig::show_item(int32_t item_id)
+	{
+		UI::get().show_item(Tooltip::Parent::KEYCONFIG, item_id);
+	}
+
+	void UIKeyConfig::show_skill(int32_t skill_id)
+	{
+		//int32_t skill_id = skill_id;
+		//int32_t level = skillbook.get_level(skill_id);
+		//int32_t masterlevel = skillbook.get_masterlevel(skill_id);
+		//int64_t expiration = skillbook.get_expiration(skill_id);
+
+		//UI::get().show_skill(Tooltip::Parent::KEYCONFIG, skill_id, level, masterlevel, expiration);
+	}
+
+	void UIKeyConfig::clear_tooltip()
+	{
+		UI::get().clear_tooltip(Tooltip::Parent::KEYCONFIG);
 	}
 
 	// Keymap Staging

--- a/IO/UITypes/UIKeyConfig.cpp
+++ b/IO/UITypes/UIKeyConfig.cpp
@@ -32,7 +32,7 @@
 
 namespace ms
 {
-	UIKeyConfig::UIKeyConfig() : UIDragElement<PosKEYCONFIG>(), dirty(false)
+	UIKeyConfig::UIKeyConfig(const Skillbook& in_skillbook) : UIDragElement<PosKEYCONFIG>(), skillbook(in_skillbook), dirty(false)
 	{
 		keyboard = &UI::get().get_keyboard();
 		staged_mappings = keyboard->get_maplekeys();
@@ -763,10 +763,6 @@ namespace ms
 				}
 			}
 		}
-		else
-		{
-			clear_tooltip();
-		}
 
 		return UIElement::send_cursor(clicked, cursorpos);
 	}
@@ -834,12 +830,11 @@ namespace ms
 
 	void UIKeyConfig::show_skill(int32_t skill_id)
 	{
-		//int32_t skill_id = skill_id;
-		//int32_t level = skillbook.get_level(skill_id);
-		//int32_t masterlevel = skillbook.get_masterlevel(skill_id);
-		//int64_t expiration = skillbook.get_expiration(skill_id);
+		int32_t level = skillbook.get_level(skill_id);
+		int32_t masterlevel = skillbook.get_masterlevel(skill_id);
+		int64_t expiration = skillbook.get_expiration(skill_id);
 
-		//UI::get().show_skill(Tooltip::Parent::KEYCONFIG, skill_id, level, masterlevel, expiration);
+		UI::get().show_skill(Tooltip::Parent::KEYCONFIG, skill_id, level, masterlevel, expiration);
 	}
 
 	void UIKeyConfig::clear_tooltip()

--- a/IO/UITypes/UIKeyConfig.h
+++ b/IO/UITypes/UIKeyConfig.h
@@ -61,6 +61,10 @@ namespace ms
 
 		void safe_close();
 
+		void show_item(int32_t item_id);
+		void show_skill(int32_t skill_id);
+		void clear_tooltip();
+
 		void save_staged_mappings();
 		void bind_staged_action_keys();
 		void clear();

--- a/IO/UITypes/UIKeyConfig.h
+++ b/IO/UITypes/UIKeyConfig.h
@@ -23,6 +23,7 @@
 #include "../Keyboard.h"
 #include "../KeyType.h"
 
+#include "../Character/Skillbook.h"
 #include "../Template/EnumMap.h"
 
 namespace ms
@@ -34,7 +35,7 @@ namespace ms
 		static constexpr bool FOCUSED = false;
 		static constexpr bool TOGGLED = true;
 
-		UIKeyConfig();
+		UIKeyConfig(const Skillbook& skillbook);
 
 		void draw(float inter) const override;
 
@@ -103,6 +104,8 @@ namespace ms
 		private:
 			Keyboard::Mapping mapping;
 		};
+
+		const Skillbook& skillbook;
 
 		bool dirty;
 

--- a/IO/UITypes/UIStatusbar.cpp
+++ b/IO/UITypes/UIStatusbar.cpp
@@ -614,7 +614,9 @@ namespace ms
 			remove_menus();
 			break;
 		case Buttons::BT_SETTING_KEYS:
-			UI::get().emplace<UIKeyConfig>();
+			UI::get().emplace<UIKeyConfig>(
+				Stage::get().get_player().get_skills()
+				);
 
 			remove_menus();
 			break;


### PR DESCRIPTION
This adds tooltips for USE items and skills in the keyconfig. Fixes #56.

My client/server pair is currently having issues with monster spawns, but in tests the issue seems unrelated to these changes here. **We should test these on someone else's setup to confirm**.

This may need to be rebased once PR #71 is landed.