### PR TITLE
Add item counts to Key Config (Fixes #54)

### DIFF
--- a/Character/Inventory/Inventory.cpp
+++ b/Character/Inventory/Inventory.cpp
@@ -321,6 +321,19 @@ namespace ms
 			return 0;
 	}
 
+	int16_t Inventory::get_total_item_count(int32_t itemid) const
+	{
+		InventoryType::Id type = InventoryType::by_item_id(itemid);
+
+		int16_t total_count = 0;
+
+		for (auto& iter : inventories[type])
+			if (iter.second.item_id == itemid)
+				total_count += iter.second.count;
+
+		return total_count;
+	}
+
 	int32_t Inventory::get_item_id(InventoryType::Id type, int16_t slot) const
 	{
 		auto iter = inventories[type].find(slot);

--- a/Character/Inventory/Inventory.h
+++ b/Character/Inventory/Inventory.h
@@ -98,6 +98,8 @@ namespace ms
 		int16_t find_item(InventoryType::Id type, int32_t itemid) const;
 		// Return the count of an item. Returns 0 if the slot is empty.
 		int16_t get_item_count(InventoryType::Id type, int16_t slot) const;
+		// Return the total count of an item. Returns 0 if no instances of item found.
+		int16_t get_total_item_count(int32_t itemid) const;
 		// Return the id of an item. Returns 0 if the slot is empty.
 		int32_t get_item_id(InventoryType::Id type, int16_t slot) const;
 

--- a/IO/UIStateGame.cpp
+++ b/IO/UIStateGame.cpp
@@ -286,6 +286,7 @@ namespace ms
 
 						if (!keyconfig || !keyconfig->is_active())
 							emplace<UIKeyConfig>(
+								Stage::get().get_player().get_inventory(),
 								Stage::get().get_player().get_skills()
 								);
 						else if (keyconfig && keyconfig->is_active())

--- a/IO/UITypes/UIKeyConfig.cpp
+++ b/IO/UITypes/UIKeyConfig.cpp
@@ -1239,31 +1239,15 @@ namespace ms
 
 	// Item count
 
-	void UIKeyConfig::modify_item_count(InventoryType::Id type, int16_t slot, int8_t mode, int16_t arg)
+	void UIKeyConfig::update_item_count(InventoryType::Id type, int16_t slot, int16_t change)
 	{
 		int32_t item_id = inventory.get_item_id(type, slot);
 
 		if (item_icons.find(item_id) == item_icons.end())
 			return;
 
-		int16_t slot_count = inventory.get_item_count(type, slot);
 		int16_t item_count = item_icons[item_id]->get_count();
-
-		switch (mode)
-		{
-		case Inventory::Modification::ADD:
-			item_icons[item_id]->set_count(item_count + slot_count);
-			break;
-		case Inventory::Modification::CHANGECOUNT:
-		{
-			int16_t new_slot_count = arg;
-			item_icons[item_id]->set_count(item_count + (new_slot_count - slot_count));
-		}
-		break;
-		case Inventory::Modification::REMOVE:
-			item_icons[item_id]->set_count(item_count - slot_count);
-			break;
-		}
+		item_icons[item_id]->set_count(item_count + change);
 	}
 
 	// MappingIcon

--- a/IO/UITypes/UIKeyConfig.cpp
+++ b/IO/UITypes/UIKeyConfig.cpp
@@ -32,7 +32,7 @@
 
 namespace ms
 {
-	UIKeyConfig::UIKeyConfig(const Skillbook& in_skillbook) : UIDragElement<PosKEYCONFIG>(), skillbook(in_skillbook), dirty(false)
+	UIKeyConfig::UIKeyConfig(const Inventory& in_inventory, const Skillbook& in_skillbook) : UIDragElement<PosKEYCONFIG>(), inventory(in_inventory), skillbook(in_skillbook), dirty(false)
 	{
 		keyboard = &UI::get().get_keyboard();
 		staged_mappings = keyboard->get_maplekeys();
@@ -491,8 +491,10 @@ namespace ms
 			if (mapping.type == KeyType::Id::ITEM)
 			{
 				int32_t item_id = mapping.action;
+				int16_t count = inventory.get_total_item_count(item_id);
 				Texture tx = get_item_texture(item_id);
-				item_icons[item_id] = std::make_unique<Icon>(std::make_unique<MappingIcon>(mapping), tx, -1);
+
+				item_icons[item_id] = std::make_unique<Icon>(std::make_unique<CountableMappingIcon>(mapping, count), tx, count);
 			}
 		}
 	}
@@ -507,6 +509,7 @@ namespace ms
 			{
 				int32_t skill_id = mapping.action;
 				Texture tx = get_skill_texture(skill_id);
+
 				skill_icons[skill_id] = std::make_unique<Icon>(std::make_unique<MappingIcon>(mapping), tx, -1);
 			}
 		}
@@ -529,6 +532,10 @@ namespace ms
 			{
 				int32_t item_id = mapping.action;
 				ficon = item_icons.at(item_id).get();
+
+				// TODO replace with more efficient InventoryHandlers solution
+				int16_t count = inventory.get_total_item_count(item_id);
+				ficon->set_count(count);
 			}
 			else if (mapping.type == KeyType::Id::SKILL)
 			{
@@ -918,8 +925,9 @@ namespace ms
 
 			if (item_icons.find(item_id) == item_icons.end())
 			{
+				int16_t count = inventory.get_total_item_count(item_id);
 				Texture tx = get_item_texture(item_id);
-				item_icons[item_id] = std::make_unique<Icon>(std::make_unique<MappingIcon>(mapping), tx, -1);
+				item_icons[item_id] = std::make_unique<Icon>(std::make_unique<CountableMappingIcon>(mapping, count), tx, count);
 			}
 		}
 		else if (mapping.type == KeyType::Id::SKILL)
@@ -1265,5 +1273,12 @@ namespace ms
 	Icon::IconType UIKeyConfig::MappingIcon::get_type()
 	{
 		return Icon::IconType::KEY;
+	}
+
+	UIKeyConfig::CountableMappingIcon::CountableMappingIcon(Keyboard::Mapping m, int16_t c) : UIKeyConfig::MappingIcon(m), count(c) {}
+
+	void UIKeyConfig::CountableMappingIcon::set_count(int16_t c)
+	{
+		count = c;
 	}
 }

--- a/IO/UITypes/UIKeyConfig.cpp
+++ b/IO/UITypes/UIKeyConfig.cpp
@@ -532,10 +532,6 @@ namespace ms
 			{
 				int32_t item_id = mapping.action;
 				ficon = item_icons.at(item_id).get();
-
-				// TODO replace with more efficient InventoryHandlers solution
-				int16_t count = inventory.get_total_item_count(item_id);
-				ficon->set_count(count);
 			}
 			else if (mapping.type == KeyType::Id::SKILL)
 			{
@@ -1238,6 +1234,35 @@ namespace ms
 		case KeyAction::Id::LENGTH:
 		default:
 			return KeyType::Id::NONE;
+		}
+	}
+
+	// Item count
+
+	void UIKeyConfig::modify_item_count(InventoryType::Id type, int16_t slot, int8_t mode, int16_t arg)
+	{
+		int32_t item_id = inventory.get_item_id(type, slot);
+
+		if (item_icons.find(item_id) == item_icons.end())
+			return;
+
+		int16_t slot_count = inventory.get_item_count(type, slot);
+		int16_t item_count = item_icons[item_id]->get_count();
+
+		switch (mode)
+		{
+		case Inventory::Modification::ADD:
+			item_icons[item_id]->set_count(item_count + slot_count);
+			break;
+		case Inventory::Modification::CHANGECOUNT:
+		{
+			int16_t new_slot_count = arg;
+			item_icons[item_id]->set_count(item_count + (new_slot_count - slot_count));
+		}
+		break;
+		case Inventory::Modification::REMOVE:
+			item_icons[item_id]->set_count(item_count - slot_count);
+			break;
 		}
 	}
 

--- a/IO/UITypes/UIKeyConfig.h
+++ b/IO/UITypes/UIKeyConfig.h
@@ -26,6 +26,8 @@
 #include "../Character/Skillbook.h"
 #include "../Template/EnumMap.h"
 
+#include "../Character/Inventory/Inventory.h"
+
 namespace ms
 {
 	class UIKeyConfig : public UIDragElement<PosKEYCONFIG>
@@ -35,7 +37,7 @@ namespace ms
 		static constexpr bool FOCUSED = false;
 		static constexpr bool TOGGLED = true;
 
-		UIKeyConfig(const Skillbook& skillbook);
+		UIKeyConfig(const Inventory& inventory, const Skillbook& skillbook);
 
 		void draw(float inter) const override;
 
@@ -94,20 +96,33 @@ namespace ms
 		class MappingIcon : public Icon::Type
 		{
 		public:
-			MappingIcon(Keyboard::Mapping);
+			MappingIcon(Keyboard::Mapping mapping);
 			MappingIcon(KeyAction::Id keyId);
 
 			void drop_on_stage() const override;
 			void drop_on_equips(Equipslot::Id eqslot) const override {}
 			bool drop_on_items(InventoryType::Id, Equipslot::Id, int16_t, bool) const override { return true; }
 			void drop_on_bindings(Point<int16_t> cursorposition, bool remove) const override;
-			void set_count(int16_t) override {}
+			void set_count(int16_t) override {};
 			Icon::IconType get_type() override;
 
 		private:
 			Keyboard::Mapping mapping;
 		};
 
+		// Used for displaying item counts
+		class CountableMappingIcon : public MappingIcon
+		{
+		public:
+			CountableMappingIcon(Keyboard::Mapping mapping, int16_t count);
+
+			void set_count(int16_t count) override;
+
+		private:
+			int16_t count;
+		};
+
+		const Inventory& inventory;
 		const Skillbook& skillbook;
 
 		bool dirty;

--- a/IO/UITypes/UIKeyConfig.h
+++ b/IO/UITypes/UIKeyConfig.h
@@ -52,6 +52,8 @@ namespace ms
 		void stage_mapping(Point<int16_t> cursorposition, Keyboard::Mapping mapping);
 		void unstage_mapping(Keyboard::Mapping mapping);
 
+		void modify_item_count(InventoryType::Id type, int16_t slot, int8_t mode, int16_t arg);
+
 	protected:
 		Button::State button_pressed(uint16_t buttonid) override;
 

--- a/IO/UITypes/UIKeyConfig.h
+++ b/IO/UITypes/UIKeyConfig.h
@@ -52,7 +52,7 @@ namespace ms
 		void stage_mapping(Point<int16_t> cursorposition, Keyboard::Mapping mapping);
 		void unstage_mapping(Keyboard::Mapping mapping);
 
-		void modify_item_count(InventoryType::Id type, int16_t slot, int8_t mode, int16_t arg);
+		void update_item_count(InventoryType::Id type, int16_t slot, int16_t change);
 
 	protected:
 		Button::State button_pressed(uint16_t buttonid) override;
@@ -105,7 +105,7 @@ namespace ms
 			void drop_on_equips(Equipslot::Id eqslot) const override {}
 			bool drop_on_items(InventoryType::Id, Equipslot::Id, int16_t, bool) const override { return true; }
 			void drop_on_bindings(Point<int16_t> cursorposition, bool remove) const override;
-			void set_count(int16_t) override {};
+			void set_count(int16_t) override {}
 			Icon::IconType get_type() override;
 
 		private:

--- a/IO/UITypes/UIStatusbar.cpp
+++ b/IO/UITypes/UIStatusbar.cpp
@@ -607,6 +607,7 @@ namespace ms
 			break;
 		case Buttons::BT_SETTING_KEYS:
 			UI::get().emplace<UIKeyConfig>(
+				Stage::get().get_player().get_inventory(),
 				Stage::get().get_player().get_skills()
 				);
 

--- a/Net/Handlers/InventoryHandlers.cpp
+++ b/Net/Handlers/InventoryHandlers.cpp
@@ -24,9 +24,10 @@
 #include "../IO/Messages.h"
 
 #include "../Character/Inventory/Inventory.h"
-#include "../IO/UITypes/UIShop.h"
 #include "../IO/UITypes/UIEquipInventory.h"
 #include "../IO/UITypes/UIItemInventory.h"
+#include "../IO/UITypes/UIKeyConfig.h"
+#include "../IO/UITypes/UIShop.h"
 
 namespace ms
 {
@@ -78,6 +79,11 @@ namespace ms
 			{
 			case Inventory::Modification::ADD:
 				ItemParser::parse_item(recv, mod.type, mod.pos, inventory);
+
+				// Must run after modifying inventory. Relies on values after changes.
+				if (auto keyconfig = UI::get().get_element<UIKeyConfig>())
+					keyconfig->modify_item_count(mod.type, mod.pos, mod.mode, mod.arg);
+
 				break;
 			case Inventory::Modification::CHANGECOUNT:
 			{
@@ -86,16 +92,25 @@ namespace ms
 				int16_t count_before = inventory.get_item_count(mod.type, mod.pos);
 				int16_t count_now = mod.arg;
 
+				// Must run before modifying inventory. Relies on values prior to changes.
+				if (auto keyconfig = UI::get().get_element<UIKeyConfig>())
+					keyconfig->modify_item_count(mod.type, mod.pos, mod.mode, mod.arg);
+
 				inventory.modify(mod.type, mod.pos, mod.mode, mod.arg, Inventory::Movement::MOVE_NONE);
 
 				if (count_before < count_now)
 					mod.mode = Inventory::Modification::ADDCOUNT;
+
 			}
 			break;
 			case Inventory::Modification::SWAP:
 				mod.arg = recv.read_short();
 				break;
 			case Inventory::Modification::REMOVE:
+				// Must run before modifying inventory. Relies on values prior to changes.
+				if (auto keyconfig = UI::get().get_element<UIKeyConfig>())
+					keyconfig->modify_item_count(mod.type, mod.pos, mod.mode, mod.arg);
+
 				inventory.modify(mod.type, mod.pos, mod.mode, mod.arg, Inventory::Movement::MOVE_INTERNAL);
 				break;
 			}


### PR DESCRIPTION
Fixes #54. Looks like SETUP items also show a count in v83 and latest GMS. Should update accurately whether the player uses, drops, or picks up items.

Plugs in to InventoryHandlers to avoid having to loop over the entire inventory list on every draw() frame, though we do loop through on initial load or whenever an item is newly added to the keyconfig.

![image](https://user-images.githubusercontent.com/58151192/71776117-d62ba200-2f59-11ea-98c7-160759e0006a.png)
