### PR TITLE
Added support for Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,32 @@
+/.vs
+/.vscode
+/x64
+.DS_Store
+
+**.nx
+*.aps
+*.log
+*.tlog
+.git/
+
+Settings
+
+/includes/**/*.sln
+/includes/**/*.vcxproj*
+/includes/**/*.txt
+/includes/**/*.gitignore
+
+# Builds
+build/
+libs/alure/
+libs/openal-soft/
+libs/glad/build/
+libs/NoLifeNx/
+libs/glfw/
+libs/asio/
+
+# Vagrant
+.vagrant/
+
+# NX file dir
+nx/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.vs
+/.vscode
 /x64
 
 *.nx
@@ -12,3 +13,11 @@ Settings
 /includes/**/*.vcxproj*
 /includes/**/*.txt
 /includes/**/*.gitignore
+
+# Builds
+build/
+libs/NoLifeNx/
+libs/alure/
+libs/asio/
+libs/glfw/
+libs/openal-soft/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.vs
 /.vscode
 /x64
+.DS_store
 
 *.nx
 *.aps

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -472,6 +472,8 @@ TARGET_LINK_LIBRARIES(HeavenClient ${PROJECT_SOURCE_DIR}/libs/alure/build/libalu
 
 TARGET_INCLUDE_DIRECTORIES(HeavenClient PUBLIC ${PROJECT_SOURCE_DIR}/libs/stb)
 
+TARGET_INCLUDE_DIRECTORIES(HeavenClient PUBLIC ${PROJECT_SOURCE_DIR}/libs/asio/asio/include)
+
 target_link_libraries(HeavenClient GL)
 target_link_libraries(HeavenClient X11)
 target_link_libraries(HeavenClient dl)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,164 @@
+# Built with arch: amd64 image: ubuntu:18.04
+#
+################################################################################
+# build system
+################################################################################
+FROM ubuntu:bionic as builder
+
+LABEL maintainer="zeeshan sarwar <dev.786zshan@gmail.com>"
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && apt-get install -y \
+    apt-transport-https \
+    ca-certificates \
+    gnupg2 \
+    software-properties-common \
+    build-essential \
+    autoconf \
+    libtool \
+    pkg-config \
+    git \
+    wget
+
+RUN wget -qO - https://apt.kitware.com/keys/kitware-archive-latest.asc | apt-key add - && \
+  apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main' && \
+  apt-get update
+
+RUN apt-get install -y \
+  cmake \
+  libopenal-dev libvorbis-dev libopusfile-dev libsndfile1-dev \
+  xorg-dev \
+  libgl1-mesa-dev
+
+
+# Explicitly copying required files into container (optimize for docker caching)
+WORKDIR /tmp/HeavenClient/
+COPY *.cpp *.h Icon.* build-deps.sh CMakeLists.txt ./
+COPY Audio ./Audio
+COPY Character ./Character
+COPY Data ./Data
+COPY Gameplay ./Gameplay
+COPY Graphics ./Graphics
+COPY IO ./IO
+COPY Net ./Net
+COPY Template ./Template
+COPY Util ./Util
+COPY libs ./libs
+COPY fonts ./fonts
+
+
+# Build all HeavenClient dependencies
+WORKDIR /tmp/HeavenClient/libs
+
+# fetch & build alure
+RUN git clone https://github.com/kcat/alure && \
+    cd alure && \
+    cd build && \
+    cmake .. && \
+    make -j$(nproc)
+
+# fetch * build openal-soft
+RUN git clone https://github.com/kcat/openal-soft && \
+  cd openal-soft && \
+  git checkout f5e0eef && \
+  cd build && \
+  cmake .. && \
+  make -j$(nproc)
+
+# build glad
+RUN cd glad && \
+  mkdir -p build && \
+  cd build && \
+  cmake .. && \
+  make -j$(nproc)
+
+# build lz4
+RUN cd lz4 && make -j$(nproc)
+
+# fetch & build NoLifeNx
+RUN mkdir NoLifeNx && \
+  cd NoLifeNx && \
+  git clone https://github.com/lain3d/NoLifeNx nlnx && \
+  cd nlnx && \
+  mkdir build && \
+  cd build && \
+  cmake .. && \
+  make -j$(nproc)
+
+# fetch & build glfw
+RUN git clone https://github.com/glfw/glfw && \
+  cd glfw && \
+  git checkout 0a49ef0 && \
+  mkdir build && \
+  cd build && \
+  cmake .. && \
+  make -j$(nproc)
+
+# fetch asio
+RUN git clone https://github.com/chriskohlhoff/asio.git
+
+
+# Building HeavenClient
+WORKDIR /tmp/HeavenClient
+RUN mkdir build && \
+  cd build && \
+  cmake .. && \
+  make -j$(nproc)
+
+
+# Move HeavenClient into distinct folder
+WORKDIR /HeavenClient
+RUN mv /tmp/HeavenClient/build/HeavenClient ./ && \
+  mv /tmp/HeavenClient/fonts ./ && \
+  mv /tmp/HeavenClient/Icon.* ./
+
+
+################################################################################
+# merge
+################################################################################
+FROM dorowu/ubuntu-desktop-lxde-vnc:bionic
+
+LABEL maintainer="zeeshan sarwar <dev.786zshan@gmail.com>"
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && \
+  apt-get install -y \
+  libfreetype6 \
+  libx11-6 \
+  libopenal-dev libvorbis-dev libopusfile-dev
+
+# Audio support for Mac (via pulseaudio)
+ENV PULSE_SERVER=host.docker.internal
+RUN apt-get install -y pulseaudio
+
+
+# Copy HeavenClient + assets
+COPY --from=builder /HeavenClient/ /root/
+
+# Copy libraries
+COPY --from=builder /tmp/HeavenClient/libs/alure/build/libalure2.so /usr/lib/x86_64-linux-gnu/libalure2.so
+
+# Set server IP
+RUN echo "ServerIP = host.docker.internal" >> /root/Settings
+
+# Create desktop executable for HeavenClient
+RUN mkdir -p /root/Desktop/
+RUN echo '#!/usr/bin/env xdg-open\n\
+[Desktop Entry]\n\
+Name=HeavenClient\n\
+Comment=Script to run HeavenClient binary\n\
+Exec=/root/HeavenClient\n\
+Icon=/root/Icon.png\n\
+Terminal=false\n\
+Type=Application'\
+> /root/Desktop/heavenclient.desktop
+RUN chmod +x /root/Desktop/heavenclient.desktop
+
+# Set entrypoint for linknx.sh file
+COPY ./docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/startup.sh"]

--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ sudo modprobe snd-aloop index=2
 Note: If the client fails to startup, then it is very likely something went wrong with the setup. The link doesn't show errors hence you will have to use the **LXTerminal** within the web-based GUI to run the client manually.
 
 - The HeaventClient binary is located within the **/root** folder of the container
+- You may need to restart your browser before trying to run the game after applying any fixes
+- You need to ```docker-compose down``` if you move your **.nx** files into the **nx/** difectory post container start-up (since symlinks are generated only when starting up fresh container)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,63 @@ Note: These steps are not applicable to linux
 
 ---
 
+## Docker Setup - web-vnc
+
+A [Dockerfile](./Dockerfile) has been included in the repo to simulate a complete HeaventClient setup on a linux ubuntu/bionic OS.
+
+The Docker setup utilizes [fcwu/docker-ubuntu-vnc-desktop](https://github.com/fcwu/docker-ubuntu-vnc-desktop) **web-based lxde VNC** solution to output HeavenClient GUI on a web browser at port **6080**.
+
+This allows the host to rely on minimal dependencies (other than nx files) for running HeavenClient.
+
+### Docker Pre-requisites
+
+- All [relevant](./Util/NxFiles.h) **.nx** files must be located in the **nx** directory
+- A [Settings](./Settings) file must be present in project root - instructions to create this [below](#building--runnning-client)
+  - This gives user ability to configure HeavenClient outside the container - on the host
+- Relevant audio passthrough device must be installed on the host
+  - Mac: [pulseaudio](https://www.freedesktop.org/wiki/Software/PulseAudio/)
+  - Linux: [snd-aloop](./https://www.alsa-project.org/wiki/Matrix:Module-aloop)
+- [HeavenMS](https://github.com/ronancpl/HeavenMS) server running at port 8484 on host machine
+
+### Installing sound passthrough device
+
+#### Mac
+
+```sh
+# Install pulseaudio
+brew install pulseaudio
+
+# Run pulseaudio daemon
+pulseaudio --load=module-native-protocol-tcp --exit-idle-time=-1 --daemon
+```
+
+Note: To stop sound passthrough daemon: ```pulseaudio --kill```
+
+#### Linux
+
+```sh
+# Insert kernel module snd-aloop and specify 2 as the index of sound loop device
+sudo modprobe snd-aloop index=2
+```
+
+### Building & Runnning Client
+
+1. Create Settings with server ip pointing to host
+   1. ```echo "ServerIP = host.docker.internal" > Settings```
+2. Build & Run container for your OS
+   1. Mac:
+      1. ```docker-compose -f docker-compose.yml -f docker-compose.mac.yml up --build```
+   2. Linux:
+      1. ```docker-compose -f docker-compose.yml -f docker-compose.linux.yml up --build```
+3. Run HeavenClient in the browser GUI at [localhost:6080](http://localhost:6080) by double clicking the HeavenClient icon
+
+</br>
+Note: If the client fails to startup, then it is very likely something went wrong with the setup. The link doesn't show errors hence you will have to use the **LXTerminal** within the web-based GUI to run the client manually.
+
+- The HeaventClient binary is located within the **/root** folder of the container
+
+---
+
 ## Donations
 
 If you feel obligated to donate, to further help and support all parties involved in the development of the HeavenClient project, you can donate using [this](https://paypal.me/pools/c/8frYNoobcY) link.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,24 @@
 # HeavenClient
-HeavenClient is a custom, made-from-scratch game client.
 
-# Supported versions
+HeavenClient is a custom, made-from-scratch game client for Maplestory v83.
+
+## Supported versions
+
 - The client is currently compatible with version 83 servers.
 - The client has only been tested with [HeavenMS](https://github.com/ronancpl/HeavenMS).
 - There is also a Switch version available here: [HeavenClientNX](https://github.com/lain3d/HeavenClientNX).
 
-# Configuration
+## Configuration
+
 The build can be configured by editing the **MapleStory.h** file. The following options are available:
+
 - **USE_ASIO**: Use Asio for networking (additional dependency)
-- **USE_CRYPTO**: Use cryptography when communicating for the server.
+- **USE_CRYPTO**: Use cryptography when communicating for the server
 
 The default settings can be configured by editing the **Configuration.h** file. These are also generated after a game session in a file called **Settings**. These can be altered in the same way as **Configuration.h**, although, these do not persist if you delete the file, unlike **Configuration.h**.
 
-# Building
+## Building
+
 *After cloning you need to check out the linux branch! To do so run ```git checkout linux``` in your HeavenClient directory.*
 
 1. Run ```./build-deps.sh```. We try to build each dependency from source -- if any dependencies fail to build, you could try and find the corresponding package for your linux distro if it exists.
@@ -22,15 +27,18 @@ The default settings can be configured by editing the **Configuration.h** file. 
 4. ```cmake ..```
 5. ```make -j$CORES``` where $CORES is your number of CPU cores
 
-# Required Files
+## Required Files
+
 *Always check **NxFiles.h** for an updated list of required nx files*
+
 - [MapPretty.nx](https://drive.google.com/file/d/1d8HJkWY6ght5OAoJGtsAjNiG2BL1wcle/view?usp=sharing) (v167 GMS Map.wz)
 - MapLatest.nx (Lastest GMS Map.wz)
 - Map001.nx (Latest GMS Map001.wz)
 - UI.nx (Latest GMS UI.wz)
 - Everything else is from v83 GMS wz files
 
-# Dependencies
+## Dependencies
+
 - Nx library:
 [NoLifeNX](https://github.com/ryantpayton/NoLifeNx)
 
@@ -38,21 +46,29 @@ The default settings can be configured by editing the **Configuration.h** file. 
 [GLFW3](http://www.glfw.org/download.html), [GLAD](https://github.com/Dav1dde/glad), [FreeType](http://www.freetype.org/)
 
 - Audio:
-[OpenAL-soft](https://github.com/kcat/openal-soft)
-[Alure](https://github.com/kcat/alure)
+[OpenAL-soft](https://github.com/kcat/openal-soft), [Alure](https://github.com/kcat/alure)
 
 - Networking:
-[Asio](http://think-async.com/) (optional)
+[Asio](http://think-async.com/)
 
-# In-Game Issues
+---
+
+## In-Game Issues
+
 If you experience any kind of in-game glitches, UI rendering issues, or anything else that seems out of the ordinary that other developers are not experiences; Follow these steps in order to hopefully resolve aforementioned issues.
+
 1. Clean Solution
 2. Close Visual Studio
 3. Delete the following files/folders: **.vs**, **x64**, **debug.log**, **MapleStory.aps**, **Settings**
 4. Open Solution
 5. Rebuild Solution
 
-# Donations
+Note: These steps are not applicable to linux
+
+---
+
+## Donations
+
 If you feel obligated to donate, to further help and support all parties involved in the development of the HeavenClient project, you can donate using [this](https://paypal.me/pools/c/8frYNoobcY) link.
 
 Please remember this is ONLY for the HeavenClient development and will only be used in the support of helping further develop the client. *Also please remember to support Nexon as this is not meant to replace anything Nexon offers*

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ sudo modprobe snd-aloop index=2
 
 1. Create Settings with server ip pointing to host
    1. ```echo "ServerIP = host.docker.internal" > Settings```
+      1. This allows the HeavenClient application within the container to point to the running hosts IP (on which the server will be running)
 2. Build & Run container for your OS
    1. Mac:
       1. ```docker-compose -f docker-compose.yml -f docker-compose.mac.yml up --build```

--- a/build-deps.sh
+++ b/build-deps.sh
@@ -2,7 +2,7 @@
 set -ex
 
 SOURCE_DIR=${PWD}
-CORES=4
+CORES=$(nproc)
 
 
 # build alure

--- a/build-deps.sh
+++ b/build-deps.sh
@@ -1,41 +1,125 @@
 #!/bin/bash
+set -ex
 
+SOURCE_DIR=${PWD}
 CORES=4
 
-if [ -d "libs/alure" ]; then
+
+# build alure
+if [[
+    ! -d "libs/alure/include" ||
+    ! -f "libs/alure/build/libalure2.so" 
+]]; then
     rm -rf "libs/alure"
+    echo "fetching and building alure..."
+    cd libs && \
+    git clone https://github.com/kcat/alure && \
+    cd alure && \
+    cd build && \
+    cmake .. && \
+    make -j$CORES
+    echo "successfully compiled alure"
+    cd $SOURCE_DIR
 fi
 
-if [ -d "libs/openal-soft" ]; then
+
+# build openal-soft 
+if [[
+    ! -d "libs/openal-soft/include" ||
+    ! -f "libs/openal-soft/build/libopenal.so"
+]]; then
     rm -rf "libs/openal-soft"
+    echo "fetching and building openal-soft..."
+    cd libs && \
+    git clone https://github.com/kcat/openal-soft && \
+    cd openal-soft && \
+    git checkout f5e0eef && \
+    cd build && \
+    cmake .. && \
+    make -j$CORES
+    echo "successfully compiled openal-soft"
+    cd $SOURCE_DIR
 fi
 
-if [ -d "libs/glad/build" ]; then
+
+# build glad
+if [[
+    ! -d "libs/glad/build/include" ||
+    ! -f "libs/glad/build/libglad.a"
+]]; then
     rm -rf "libs/glad/build"
+    echo "building glad..."
+    cd libs && \
+    cd glad && \
+    mkdir build && \
+    cd build && \
+    cmake .. && \
+    make -j$CORES
+    echo "successfully compiled glad"
+    cd $SOURCE_DIR
 fi
 
-if [ -d "libs/NoLifeNx" ]; then
+
+# build lz4
+if [[
+    ! -f "libs/lz4/lib/liblz4.a"
+]]; then
+    echo "building lz4..."
+    cd libs/lz4 && \
+    make -j$CORES && \
+    echo "successfully compiled lz4"
+    cd $SOURCE_DIR
+fi
+
+# build NoLifeNx
+if [[
+    ! -f "libs/NoLifeNx/nlnx/build/libNoLifeNx.a"
+]]; then
     rm -rf "libs/NoLifeNx"
+    echo "fetching and building NoLifeNx..."
+    cd libs && \
+    mkdir NoLifeNx && \
+    cd NoLifeNx && \
+    git clone https://github.com/lain3d/NoLifeNx nlnx && \
+    cd nlnx && \
+    mkdir build && \
+    cd build && \
+    cmake .. && \
+    make -j$CORES && \
+    echo "successfully compiled NoLifeNx"
+    cd $SOURCE_DIR
 fi
 
-if [ -d "libs/glfw" ]; then
+
+# build glfw
+if [[
+    ! -d "libs/glfw/include" ||
+    ! -f "libs/glfw/build/src/libglfw3.a"
+]]; then
     rm -rf "libs/glfw"
+    echo "fetching and building glfw..."
+    cd libs && \
+    git clone https://github.com/glfw/glfw && \
+    cd glfw && \
+    git checkout 0a49ef0 && \
+    mkdir build && \
+    cd build && \
+    cmake .. && \
+    make -j$CORES && \
+    echo "successfully compiled glfw"
+    cd $SOURCE_DIR
 fi
 
-cd libs && \
-git clone https://github.com/kcat/alure && cd alure 
-cd build && cmake .. && make -j$CORES && cd ../../ && \
-\
-git clone https://github.com/kcat/openal-soft && cd openal-soft && \
-git checkout f5e0eef && cd build && cmake .. && make -j$CORES && cd ../../ && \
-\
-cd glad && mkdir build && cd build && cmake .. && make -j$CORES && cd ../../ && \
-\
-cd lz4 && make -j$CORES && cd ../ && \
-\
-mkdir NoLifeNx && cd NoLifeNx && git clone https://github.com/lain3d/NoLifeNx nlnx && cd nlnx && \
-mkdir build && cd build && cmake .. && make -j$CORES && cd ../../../ && \
-\
-git clone https://github.com/glfw/glfw && cd glfw && git checkout 0a49ef0 && \
-mkdir build && cd build && cmake .. && make -j$CORES
+
+# fetch asio
+if [[
+    ! -d "libs/asio/asio/include"
+]]; then
+    rm -rf "libs/asio"
+    echo "fetching asio..."
+    cd libs && \
+    git clone https://github.com/chriskohlhoff/asio.git && \
+    echo "successfully fetched asio"
+    cd $SOURCE_DIR
+fi
 

--- a/docker-compose.linux.yml
+++ b/docker-compose.linux.yml
@@ -1,0 +1,8 @@
+version: '3'
+
+services:
+  heavenclient:
+    environment:
+      ALSADEV: hw:2,0
+    devices: 
+      - /dev/snd:/dev/snd

--- a/docker-compose.mac.yml
+++ b/docker-compose.mac.yml
@@ -1,0 +1,8 @@
+version: '3'
+
+services:
+  heavenclient:
+    volumes:
+      - ${PULSE_FILE:-~/.config/pulse}:/root/.config/pulse
+    environment:
+      PULSE_SERVER: host.docker.internal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+
+services:
+  heavenclient:
+    build: .
+    container_name: heavenclient
+    volumes:
+      - ./nx/:/root/nx/
+      - ./Settings:/root/Settings
+    ports:
+      - 6080:80

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -ex
+
+# Symlink all host-mounted nx files to the container
+ln -s /root/nx/* /root/
+
+exec "$@"


### PR DESCRIPTION
- heavenclient can now run completely with docker on a Mac/Linux host.
- Ubuntu lxde is the docker environment used, vnc-web forwarding is used to allow user to view the client and underlying container on a web browser
- readme updated with instructions for docker based setup